### PR TITLE
fix(ci): close/reopen release PR to trigger CI checks

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,17 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # PRs created by GITHUB_TOKEN don't trigger CI. Close/reopen to trigger.
+      - name: Trigger CI on release PR
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.release.outputs.pr }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr close "$PR_NUMBER" --repo "$REPO"
+          gh pr reopen "$PR_NUMBER" --repo "$REPO"
+
       - name: Enable auto-merge on release PR
         if: ${{ steps.release.outputs.pr }}
         env:


### PR DESCRIPTION
## Summary
- PRs created by `GITHUB_TOKEN` don't trigger CI (GitHub's infinite loop prevention)
- Added close/reopen step so the release PR triggers required status checks
- Without this, auto-merge blocks forever waiting for checks that never run

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, release-please creates PR, CI runs on it, auto-merge proceeds
- [ ] GitHub release created → publish.yml fires → PyPI upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)