### PR TITLE
fix(ci): use PAT for release-please to trigger CI on release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,23 +19,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      # PRs created by GITHUB_TOKEN don't trigger CI. Close/reopen to trigger.
-      - name: Trigger CI on release PR
-        if: ${{ steps.release.outputs.pr }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.release.outputs.pr }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh pr close "$PR_NUMBER" --repo "$REPO"
-          gh pr reopen "$PR_NUMBER" --repo "$REPO"
-
-      - name: Enable auto-merge on release PR
-        if: ${{ steps.release.outputs.pr }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.release.outputs.pr }}
-          REPO: ${{ github.repository }}
-        run: gh pr merge --auto --squash "$PR_NUMBER" --repo "$REPO" || true
+          token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary
- Uses `RELEASE_TOKEN` (fine-grained PAT) instead of `GITHUB_TOKEN`
- PRs created by PAT trigger CI automatically — no close/reopen hacks
- Removed all workaround steps, workflow is now 22 lines

## PAT details
- Name: `elnora-cli-release-please`
- Scope: `Elnora-AI/elnora-cli` only
- Permissions: Contents (R/W), Pull requests (R/W), Metadata (R)
- Expiration: never

## Test plan
- [ ] CI passes on this PR
- [ ] After merge: release-please creates release PR → CI runs → merge → GH release → PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)