### PR TITLE
fix(cli): use correct endpoint key for org delete

### DIFF
--- a/src/elnora/lib/client.py
+++ b/src/elnora/lib/client.py
@@ -688,7 +688,7 @@ class ElnoraClient:
     def delete_organization(self, org_id: str) -> dict:
         """Delete an organization (SystemAdmin only). This is irreversible."""
         validate_guid(org_id, "org_id")
-        endpoint = config.ENDPOINTS["organization_delete"].replace("{id}", org_id)
+        endpoint = config.ENDPOINTS["organization"].replace("{id}", org_id)
         return self._request(endpoint, method="DELETE")
 
     def list_all_organizations(self) -> dict:


### PR DESCRIPTION
## Summary
- Fixed `KeyError: 'organization_delete'` when running `elnora orgs delete` — the key doesn't exist in the ENDPOINTS dict, should use `organization` instead

## Context
Discovered while cleaning up hackathon orgs. The delete command was added but used a non-existent endpoint key, so it always crashed with a KeyError before even hitting the API.

## Test plan
- [ ] `elnora orgs delete <id> --yes` no longer throws KeyError
- [ ] Successfully calls DELETE `/organizations/{id}` on the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)