### PR TITLE
chore: add Repo: elnora-cli label to vulnerability workflows

### DIFF
--- a/.github/workflows/codeql-to-issues.yml
+++ b/.github/workflows/codeql-to-issues.yml
@@ -164,7 +164,7 @@ jobs:
                   repo: context.repo.repo,
                   title: issueTitle,
                   body: issueBody,
-                  labels: ['Source: CodeQL', 'Flag: security', severityLabel]
+                  labels: ['Source: CodeQL', 'Flag: security', 'Repo: elnora-cli', severityLabel]
                 });
 
                 console.log(`Created issue for CodeQL #${alertNumber}: ${ruleId}`);

--- a/.github/workflows/dependabot-to-issues.yml
+++ b/.github/workflows/dependabot-to-issues.yml
@@ -164,7 +164,7 @@ jobs:
                   repo: context.repo.repo,
                   title: issueTitle,
                   body: issueBody,
-                  labels: ['Source: Vulnerability Scan', 'Flag: security', severityLabel]
+                  labels: ['Source: Vulnerability Scan', 'Flag: security', 'Repo: elnora-cli', severityLabel]
                 });
 
                 console.log(`Created issue for ${identifier}: ${packageName}`);


### PR DESCRIPTION
## Summary

Add `Repo: elnora-cli` label to dependabot-to-issues and codeql-to-issues workflows so issues are identifiable by source repo in the shared Linear Security team.

## Test plan

- [ ] Merge and trigger any workflow manually
- [ ] Verify new issues include the `Repo: elnora-cli` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)