### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elnora-ai/cli",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Elnora AI Platform CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bump version from 0.0.1 to 1.0.0 for first stable release.

After merging, create a GitHub Release with tag `v1.0.0` to trigger the release workflow (builds binaries, publishes to npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)