### PR TITLE
fix(skills): rewrite all skills to match TypeScript CLI architecture

### DIFF
--- a/skills/elnora-admin/SKILL.md
+++ b/skills/elnora-admin/SKILL.md
@@ -5,7 +5,8 @@ description: >
   "revoke API key", "check health", "submit feedback", "view audit log",
   "shell completions", "account details", "accept terms", "validate token", "elnora setup",
   "api key policy", "delete account", "list users", "feature flags", "legal documents",
-  "set feature flag", "manage legal docs", "list profiles", "show profiles",
+  "set feature flag", "manage legal docs", "list profiles", "show profiles", "whoami",
+  "run diagnostics", "open platform",
   or any task involving Elnora Platform authentication, administration, or diagnostics.
 ---
 
@@ -15,8 +16,8 @@ Authentication, API key management, account settings, health checks, audit logs,
 
 ## Invocation
 
-```
-CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
+```bash
+CLI="elnora"
 ```
 
 ## Authentication
@@ -24,47 +25,38 @@ CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
 ### Login
 
 ```bash
-$CLI auth login
 $CLI --compact auth login --api-key <KEY>
+$CLI --compact auth login --api-key <KEY> --profile university
 ```
 
-Interactive login prompts for the API key and saves to `~/.elnora/profiles.toml`. The `--api-key` flag is insecure (visible in process listings) -- prefer interactive prompt or env var.
+`--api-key` is required — there is no interactive prompt. Keys must start with `elnora_live_` and be 20+ characters. Saves to `~/.elnora/profiles.toml`.
 
-Keys must start with `elnora_live_` and be 20+ characters.
-
-Response: `{"authenticated":true,"profile":"<name>","configPath":"/Users/<you>/.elnora/profiles.toml","totalProjects":N}`
+Response: `{"profile":"default","verified":true,"configPath":"/Users/<you>/.elnora/profiles.toml"}`
 
 ### Check Auth Status
 
 ```bash
 $CLI --compact auth status
-# -> {"authenticated":true,"profile":"default","totalProjects":N}
+# -> {"profile":"default","authenticated":true,"projectCount":N}
 ```
-
-Quick way to verify the CLI is properly configured.
 
 ### Logout
 
 ```bash
 $CLI --compact auth logout
-# -> {"loggedOut":true,"profile":"default","message":"Profile 'default' removed."}
-
 $CLI --compact auth logout --all
-# -> {"loggedOut":true,"removed":"/Users/<you>/.elnora/profiles.toml","message":"All profiles removed."}
 ```
 
-Removes saved credentials from disk. Without `--all`, removes the current profile only. With `--all`, deletes the entire `profiles.toml` file.
-
-If the profile doesn't exist, exits 0 with `"message":"Profile '<name>' not found."`.
+Without `--all`, removes the current profile. With `--all`, removes all saved profiles from `profiles.toml`.
 
 ### List Profiles
 
 ```bash
 $CLI --compact auth profiles
-# -> {"profiles":[{"name":"default","apiKey":"elnora_live_...abcd"},{"name":"university","apiKey":"elnora_live_...wxyz"}]}
+# -> {"profiles":[{"name":"default","apiKey":"elnora_live_...abcd"}]}
 ```
 
-Shows all configured profiles with masked API keys. Useful for verifying multi-org setup.
+Shows all configured profiles with masked API keys.
 
 ### Validate Token
 
@@ -73,7 +65,16 @@ $CLI --compact auth validate
 $CLI --compact auth validate --token <TOKEN>
 ```
 
-Validates the current API key (or a specific token). Useful for debugging auth issues.
+Validates the current API key (or a specific token).
+
+### Who Am I
+
+```bash
+$CLI whoami
+$CLI --json whoami
+```
+
+Shows current profile, masked API key, and organization name.
 
 ## API Key Management
 
@@ -83,11 +84,6 @@ Validates the current API key (or a specific token). Useful for debugging auth i
 $CLI --compact api-keys create --name "CI Pipeline"
 $CLI --compact api-keys create --name "Agent Key" --scopes "read,write"
 ```
-
-| Flag | Required | Notes |
-|------|----------|-------|
-| `--name` | Yes | Key name for identification |
-| `--scopes` | No | Comma-separated scope list |
 
 **IMPORTANT:** The key value is only shown once in the response. Store it securely.
 
@@ -104,7 +100,7 @@ $CLI --compact api-keys revoke <KEY_ID>
 # -> {"revoked":true,"keyId":"..."}
 ```
 
-Destructive -- confirm with user first.
+Destructive — confirm with user first.
 
 ### Get API Key Policy
 
@@ -113,14 +109,11 @@ $CLI --compact api-keys get-policy
 # -> {"policy":"all_members"}
 ```
 
-Shows whether all org members or only admins can create API keys.
-
 ### Set API Key Policy
 
 ```bash
 $CLI --compact api-keys set-policy --policy admins_only
 $CLI --compact api-keys set-policy --policy all_members
-# -> {"updated":true,"policy":"admins_only"}
 ```
 
 Org admin/owner only. Values: `all_members` or `admins_only`.
@@ -133,7 +126,7 @@ Org admin/owner only. Values: `all_members` or `admins_only`.
 $CLI --compact account get <USER_ID>
 ```
 
-Returns account details. **`<USER_ID>` is an integer (e.g. `42`), NOT a UUID.** Get user IDs from `account users`.
+`<USER_ID>` is positional. Get user IDs from `account users`.
 
 ### Update Account
 
@@ -141,7 +134,7 @@ Returns account details. **`<USER_ID>` is an integer (e.g. `42`), NOT a UUID.** 
 $CLI --compact account update <USER_ID> --first-name Jane --last-name Doe
 ```
 
-**`<USER_ID>` is an integer, not a UUID.** Must provide at least one of `--first-name` or `--last-name`.
+Must provide at least one of `--first-name` or `--last-name`.
 
 ### List Agreements
 
@@ -149,25 +142,22 @@ $CLI --compact account update <USER_ID> --first-name Jane --last-name Doe
 $CLI --compact account agreements
 ```
 
-Lists all terms/agreement documents.
-
 ### Accept Terms
 
 ```bash
-$CLI --compact account accept-terms --document-version-id <VERSION_ID>
+$CLI --compact account accept-terms <DOCUMENT_VERSION_ID>
 ```
 
-`--document-version-id` is required (integer).
+`<DOCUMENT_VERSION_ID>` is positional.
 
 ### Delete Account
 
 ```bash
 $CLI --compact account delete
 $CLI --compact account delete --yes
-# -> {"deleted":true,"account":"current user"}
 ```
 
-**DANGEROUS: Permanently deletes the user's account and all associated data. Irreversible.**
+**DANGEROUS: Permanently deletes the user's account. Irreversible.**
 Requires typing "DELETE" to confirm. Use `--yes` to skip (non-interactive/CI only).
 
 ### List Users (SystemAdmin)
@@ -178,7 +168,7 @@ $CLI --compact account users --state Active
 $CLI --compact account users --state Deleted --ref-code ABC123
 ```
 
-SystemAdmin only. Optional filters: `--state` (Active, Pending, Deleted), `--ref-code`.
+Optional filters: `--state` (Active, Pending, Deleted), `--ref-code`.
 
 ### Add Legal Document Version (SystemAdmin)
 
@@ -189,8 +179,8 @@ $CLI --compact account add-legal-doc --document-type TermsOfService --version "2
 | Flag | Required | Notes |
 |------|----------|-------|
 | `--document-type` | Yes | e.g. TermsOfService, PrivacyPolicy |
-| `--version` | Yes | Version string (e.g. "1.0") |
-| `--content` | Yes | Document content (text/markdown) |
+| `--version` | Yes | Version string |
+| `--content` | Yes | Document content |
 | `--effective-date` | No | ISO 8601 date |
 
 ### Update Legal Document Version (SystemAdmin)
@@ -200,18 +190,15 @@ $CLI --compact account update-legal-doc <VERSION_ID> --content "Updated terms...
 $CLI --compact account update-legal-doc <VERSION_ID> --effective-date 2026-05-01
 ```
 
-Must provide at least one of `--content` or `--effective-date`.
+`<VERSION_ID>` is positional. Must provide at least one of `--content` or `--effective-date`.
 
 ### Delete Legal Document Version (SystemAdmin)
 
 ```bash
-$CLI --compact account delete-legal-doc <VERSION_ID>
 $CLI --compact account delete-legal-doc <VERSION_ID> --yes
-# -> {"deleted":true,"documentVersionId":N}
 ```
 
-**DANGEROUS: Permanently deletes the legal document version. Irreversible.**
-Requires typing "DELETE" to confirm. Use `--yes` to skip.
+`<VERSION_ID>` is positional. Requires confirmation unless `--yes`.
 
 ## Feature Flags (SystemAdmin)
 
@@ -221,32 +208,55 @@ Requires typing "DELETE" to confirm. Use `--yes` to skip.
 $CLI --compact flags list
 ```
 
-Returns all global feature flags with key, name, description, and value.
-
 ### Get Feature Flag
 
 ```bash
-$CLI --compact flags get <KEY>
-# -> {"key":"enable-new-editor","value":true}
+$CLI --compact flags get --key enable-new-editor
 ```
+
+`--key` is a required flag (not positional).
 
 ### Set Feature Flag
 
 ```bash
-$CLI --compact flags set enable-new-editor true
-$CLI --compact flags set enable-new-editor false --yes
-# -> {"updated":true,"key":"enable-new-editor","value":true}
+$CLI --compact flags set --key enable-new-editor --value true --yes
 ```
 
-**WARNING: Affects ALL users on the platform.** Without `--yes`, blocks on an interactive yes/no prompt. Always use `--yes` in agent context.
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--key` | Yes | Flag key name |
+| `--value` | Yes | `true` or `false` |
+| `--yes` | No | Skip confirmation prompt |
 
-## Health Check
+**WARNING: Affects ALL users on the platform.** Always use `--yes` in agent context.
+
+## Health & Diagnostics
+
+### Health Check
 
 ```bash
 $CLI health
 ```
 
-No auth required. Checks if the Elnora platform is reachable. Returns `{"status":"ok","httpStatus":200}` on success. Exits 6 if unhealthy or unreachable.
+No auth required. Returns `{"status":"ok","timestamp":"..."}` on success. Exits 1 if unreachable (network error).
+
+### Doctor
+
+```bash
+$CLI doctor
+```
+
+Runs diagnostic checks: API reachability, authentication, version currency, config permissions, AI server reachability.
+
+### Open Platform
+
+```bash
+elnora open              # Opens platform (default)
+elnora open docs         # Opens documentation
+elnora open keys         # Opens API keys page
+elnora open billing      # Opens billing page
+elnora open github       # Opens GitHub repo
+```
 
 ## Audit Log
 
@@ -256,7 +266,7 @@ $CLI --compact audit list --org <ORG_ID> --action "project.created" --user-id <U
 $CLI --compact audit list --org <ORG_ID> --page 2 --page-size 50
 ```
 
-`--org` is required. Optional filters: `--action`, `--user-id`.
+`--org` is a required flag. Optional filters: `--action`, `--user-id`.
 
 ## Feedback
 
@@ -264,7 +274,7 @@ $CLI --compact audit list --org <ORG_ID> --page 2 --page-size 50
 $CLI --compact feedback submit --title "Feature request" --description "Add batch export"
 ```
 
-Both `--title` and `--description` are required. Creates a Linear issue for the Elnora team.
+Both `--title` and `--description` are required.
 
 ## Shell Completions
 
@@ -272,14 +282,11 @@ Both `--title` and `--description` are required. Creates a Linear issue for the 
 elnora completion bash >> ~/.bashrc
 elnora completion zsh >> ~/.zshrc
 elnora completion fish > ~/.config/fish/completions/elnora.fish
-elnora completion powershell >> $PROFILE
 ```
-
-Generates shell-specific completion scripts. Run once during setup.
 
 ## Agent Recipes
 
-**Verify setup is working:**
+**Verify setup:**
 
 ```bash
 $CLI health && $CLI --compact auth status
@@ -288,18 +295,7 @@ $CLI health && $CLI --compact auth status
 **Rotate an API key:**
 
 ```bash
-# 1. Create new key
 $CLI --compact api-keys create --name "Replacement Key"
-# 2. Update .env with the new key
-# 3. Verify
-$CLI --compact auth status
-# 4. Revoke old key
+# Update .env with the new key, then:
 $CLI --compact api-keys revoke <OLD_KEY_ID>
-```
-
-**Check audit trail for an org:**
-
-```bash
-ORG=$($CLI --compact orgs list | jq -r '.items[0].id')
-$CLI --compact audit list --org "$ORG" --page-size 50
 ```

--- a/skills/elnora-agent/SKILL.md
+++ b/skills/elnora-agent/SKILL.md
@@ -12,65 +12,53 @@ description: >
 
 # Elnora Agent Capabilities
 
-The Elnora Agent is a sandboxed Python environment with ~78 core tools + 2,100 ToolUniverse scientific tools. You interact via `tasks send` — don't reference internal tool names, just describe what you need in plain language.
+The Elnora Agent is a sandboxed Python environment with ~78 core tools + 2,100 ToolUniverse scientific tools. Interact via `tasks create` and `tasks send` — describe what you need in plain language.
+
+## Quick Start
 
 ```bash
-CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
+CLI="elnora"
 
-# Create a task
+# Create a task and wait for the response
 $CLI --compact tasks create --project <PROJECT_ID> --title "My task" --message "Your request"
 
-# Continue conversation
-$CLI --compact tasks send <TASK_ID> --message "Follow-up request"
+# Send follow-up and wait for response
+$CLI --compact tasks send <TASK_ID> --message "Follow-up request" --wait
 
-# Read response
-$CLI --compact tasks messages <TASK_ID> --limit 5
+# Or stream the response in real-time
+$CLI --compact tasks send <TASK_ID> --message "Follow-up request" --stream
 ```
 
-## What the agent can do
+## What the Agent Can Do
 
 | Capability | Examples |
 |------------|----------|
 | **Web search** (34 tools) | Real-time search, neural/semantic search, deep research, URL extraction, site crawling. Providers: Tavily, Exa, Valyu, Perplexity |
 | **Academic databases** (12 tools) | PubMed, ArXiv, Semantic Scholar, bioRxiv, Europe PMC, OpenAlex, UniProt, ClinicalTrials.gov, ChEMBL, Wolfram Alpha |
 | **2,100+ scientific tools** (ToolUniverse) | Protein structure (AlphaFold, PDB), genomics (Ensembl, ClinVar), chemistry (PubChem, DrugBank), pathways (KEGG, Reactome), drug safety (OpenFDA), and 21 more categories |
-| **35 domain skills** | Literature review, experimental design, drug discovery workflow, protein engineering, single-cell RNA QC, statistical analysis, scientific writing, and more |
+| **35 domain skills** | Literature review, experimental design, drug discovery workflow, protein engineering, single-cell RNA QC, statistical analysis, scientific writing |
 | **File operations** (11 tools) | Create/read/search files, full-text grep, upload attachments, link files to tasks |
 | **Memory** (9 tools) | Remember facts across tasks, share findings between agents, recall prior context |
 | **Code execution** | Persistent Python REPL with pandas, numpy, biopython. Variables survive across executions. 30s timeout, 1MB output max |
 
-## Good prompts
+## Example Prompts
 
 ```bash
 # Web research
-$CLI --compact tasks create --project "$PROJECT" --title "Web research" \
-  --message "Search for recent CRISPR delivery methods and summarize the top findings"
+$CLI --compact tasks send "$TASK" --message "Search for recent CRISPR delivery methods and summarize" --wait
 
 # Literature review
-$CLI --compact tasks send "$TASK" \
-  --message "Search PubMed for BRCA1 DNA repair papers from 2024, find the most cited ones"
+$CLI --compact tasks send "$TASK" --message "Search PubMed for BRCA1 DNA repair papers from 2024" --wait
 
 # Drug target research
-$CLI --compact tasks send "$TASK" \
-  --message "Search for compounds targeting EGFR, cross-reference with active clinical trials"
+$CLI --compact tasks send "$TASK" --message "Search for compounds targeting EGFR, cross-reference with active clinical trials" --wait
 
 # Scientific computation
-$CLI --compact tasks send "$TASK" \
-  --message "Use ToolUniverse to run AlphaFold on this sequence: MVLSPADKTNVKAAWGKVGA"
+$CLI --compact tasks send "$TASK" --message "Use ToolUniverse to run AlphaFold on this sequence: MVLSPADKTNVKAAWGKVGA" --stream
 
 # Memory
-$CLI --compact tasks send "$TASK" \
-  --message "Remember that our lab uses Q5 polymerase for all high-fidelity PCR at 62C"
-
-# File search
-$CLI --compact tasks send "$TASK" \
-  --message "Search all project files for mentions of 'annealing temperature' and summarize"
+$CLI --compact tasks send "$TASK" --message "Remember that our lab uses Q5 polymerase for all high-fidelity PCR at 62C" --wait
 
 # Reference existing files
-$CLI --compact tasks send "$TASK" \
-  --message "Read the attached template and generate a new version" --file-refs "<FILE_ID>"
+$CLI --compact tasks send "$TASK" --message "Read the attached template and generate a new version" --file-refs "<FILE_ID>" --wait
 ```
-
-## Full tool reference
-
-Detailed tool-by-tool documentation is in the vault at `04-engineering/elnora-agent-*-tools.md`.

--- a/skills/elnora-files/SKILL.md
+++ b/skills/elnora-files/SKILL.md
@@ -10,12 +10,12 @@ description: >
 
 # Elnora Files
 
-Browse, read, create, upload, version, and manage files on the Elnora AI Platform. Files are protocol outputs, templates, datasets, and other artifacts attached to projects.
+Browse, read, create, upload, version, and manage files on the Elnora AI Platform.
 
 ## Invocation
 
-```
-CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
+```bash
+CLI="elnora"
 ```
 
 ## Commands
@@ -28,11 +28,7 @@ $CLI --compact files list --project <PROJECT_ID> --page 2 --page-size 50
 $CLI --compact --fields "id,name" files list --project <PROJECT_ID>
 ```
 
-`--project` is required. Response:
-
-```json
-{"items":[{"id":"<UUID>","name":"...","mimeType":"...","size":N,"createdAt":"...","updatedAt":"..."}],"page":1,"totalCount":N,"hasNextPage":false}
-```
+`--project` is required.
 
 ### Get File Metadata
 
@@ -40,7 +36,7 @@ $CLI --compact --fields "id,name" files list --project <PROJECT_ID>
 $CLI --compact files get <FILE_ID>
 ```
 
-Returns metadata (name, type, size, timestamps) without the actual content. Use to inspect a file before reading.
+Returns metadata (name, type, size, timestamps) without actual content.
 
 ### Get File Content
 
@@ -48,13 +44,13 @@ Returns metadata (name, type, size, timestamps) without the actual content. Use 
 $CLI files content <FILE_ID>
 ```
 
-Returns raw file content to stdout (not JSON-wrapped). Pipe to a file to save:
+Returns raw file content to stdout. Pipe to save:
 
 ```bash
 $CLI files content <FILE_ID> > protocol.md
 ```
 
-Note: `--compact` or `--fields` wraps output in `{"content":"..."}` JSON. Omit both to get raw text output. Same applies to `download` and `version-content`.
+Note: `--compact` or `--fields` wraps output in JSON. Omit both for raw text.
 
 ### Download File
 
@@ -62,7 +58,7 @@ Note: `--compact` or `--fields` wraps output in `{"content":"..."}` JSON. Omit b
 $CLI files download <FILE_ID>
 ```
 
-Downloads raw file content. Same behavior as `content` — raw output to stdout.
+Downloads file content via the `/download` endpoint (may differ from `content` in backend handling).
 
 ### Get Version History
 
@@ -71,15 +67,13 @@ $CLI --compact files versions <FILE_ID>
 $CLI --compact files versions <FILE_ID> --page-size 10
 ```
 
-Returns paginated list of file versions. Use to track how a protocol evolved across task iterations.
-
 ### Get Version Content
 
 ```bash
 $CLI files version-content <FILE_ID> <VERSION_ID>
 ```
 
-Returns the content of a specific file version. Raw output to stdout by default.
+Both `<FILE_ID>` and `<VERSION_ID>` are positional. Returns raw content.
 
 ### Create Version
 
@@ -88,15 +82,13 @@ $CLI --compact files create-version <FILE_ID>
 $CLI --compact files create-version <FILE_ID> --content "Updated protocol text"
 ```
 
-Creates a new version of a file. `--content` is optional.
-
 ### Restore Version
 
 ```bash
 $CLI --compact files restore <FILE_ID> <VERSION_ID>
 ```
 
-Restores a file to a specific previous version. Destructive — confirm with user first.
+Both positional. Destructive — confirm with user first.
 
 ### Create File
 
@@ -110,42 +102,38 @@ $CLI --compact files create --project <PROJECT_ID> --name "data.csv" --type Data
 | `--project` | Yes | Project UUID |
 | `--name` | Yes | File name |
 | `--type` | Yes | File type (e.g. Document, Protocol, Dataset) |
-| `--folder` | No | Folder UUID to place the file in |
+| `--folder` | No | Folder UUID |
 
 ### Upload File
 
-**Limits:** Max 100 MB per file, filename max 255 chars, any MIME type accepted. Presigned URL expires in 15 minutes.
-
 ```bash
-$CLI --compact files upload --project <PROJECT_ID> --file /path/to/local/file.md
-$CLI --compact files upload --project <PROJECT_ID> --file /path/to/data.csv --file-name "renamed.csv" --content-type "text/csv"
+$CLI --compact files upload --project <PROJECT_ID> --file-path /path/to/file.md
+$CLI --compact files upload --project <PROJECT_ID> --file-path /path/to/data.csv --file-name "renamed.csv" --content-type "text/csv"
 ```
 
-Three-step process (handled automatically): gets presigned URL, uploads content, confirms upload.
+Three-step process (handled automatically): presigned URL, upload, confirm.
 
 | Flag | Required | Notes |
 |------|----------|-------|
 | `--project` | Yes | Project UUID |
-| `--file` | Yes | Local file path |
-| `--file-name` | No | Override filename (defaults to local name) |
-| `--content-type` | No | MIME type (auto-detected if omitted) |
+| `--file-path` | Yes | Local file path |
+| `--file-name` | No | Override filename |
+| `--content-type` | No | MIME type (defaults to application/octet-stream) |
 
 ### Upload Batch
 
 ```bash
-$CLI --compact files upload-batch --project <PROJECT_ID> --files "a.pdf,b.docx,c.txt"
-$CLI --compact files upload-batch --project <PROJECT_ID> --files "file1.md,file2.md" --folder <FOLDER_ID>
+$CLI --compact files upload-batch --project <PROJECT_ID> --file-paths "a.pdf,b.docx,c.txt"
+$CLI --compact files upload-batch --project <PROJECT_ID> --file-paths "file1.md,file2.md" --folder <FOLDER_ID>
 ```
 
-Uploads up to 50 files in a single batch. Gets presigned URLs in bulk, uploads each file, and confirms all.
+Uploads up to 50 files. Returns per-file success/failure results.
 
 | Flag | Required | Notes |
 |------|----------|-------|
 | `--project` | Yes | Project UUID |
-| `--files` | Yes | Comma-separated local file paths |
+| `--file-paths` | Yes | Comma-separated local file paths |
 | `--folder` | No | Folder UUID (applies to all files) |
-
-Returns a list of results per file with status (success/failed).
 
 ### Confirm Upload
 
@@ -153,7 +141,7 @@ Returns a list of results per file with status (success/failed).
 $CLI --compact files confirm-upload <FILE_ID>
 ```
 
-Manually confirms a file upload. Only needed if the `upload` command was interrupted after the PUT step.
+Only needed if `upload` was interrupted after the PUT step.
 
 ### Update File
 
@@ -179,7 +167,7 @@ Destructive — confirm with user before running.
 $CLI --compact files promote <FILE_ID> --visibility <LEVEL>
 ```
 
-Promotes a file's visibility level. `--visibility` is required.
+`--visibility` is required.
 
 ### Fork File
 
@@ -187,7 +175,7 @@ Promotes a file's visibility level. `--visibility` is required.
 $CLI --compact files fork <FILE_ID> --target-project <PROJECT_ID>
 ```
 
-Copies a file into another project. `--target-project` is required.
+`<FILE_ID>` is positional (`fileId`). `--target-project` is a flag (`targetProject` doesn't end in "Id").
 
 ### Working Copy
 
@@ -196,30 +184,26 @@ $CLI --compact files working-copy <FILE_ID>
 $CLI --compact files working-copy <FILE_ID> --task <TASK_ID>
 ```
 
-Creates a working copy of a file, optionally linked to a task.
-
 ### Commit Working Copy
 
 ```bash
 $CLI --compact files commit <FILE_ID>
 ```
 
-Commits a working copy back as a new version.
-
 ### Search File Content
 
 ```bash
-$CLI --compact files search-content -q "annealing temperature"
-$CLI --compact files search-content -q "BRCA1" --project <PROJECT_ID>
-$CLI --compact files search-content -q "gel electrophoresis" --page-size 10
+$CLI --compact files search-content --query "annealing temperature"
+$CLI --compact files search-content --query "BRCA1" --project <PROJECT_ID>
+$CLI --compact files search-content --query "gel electrophoresis" --page-size 10
 ```
 
-Full-text search inside file contents. Optional `--project` to limit to a specific project. Same command is also available as `search file-content`.
+Full-text search inside file contents. Also available as `search file-content`.
 
 | Flag | Required | Notes |
 |------|----------|-------|
-| `--query` / `-q` | Yes | Search query string |
-| `--project` | No | Project UUID to filter by |
+| `--query` | Yes | Search query string (no `-q` shorthand) |
+| `--project` | No | Project UUID to filter |
 | `--page` | No | Page number (default 1) |
 | `--page-size` | No | Results per page (default 25, max 100) |
 
@@ -228,50 +212,22 @@ Full-text search inside file contents. Optional `--project` to limit to a specif
 **Read a protocol from a project:**
 
 ```bash
-# 1. List files in the project
 $CLI --compact --fields "id,name" files list --project <PROJECT_ID>
-
-# 2. Read the content of the target file
 $CLI files content <FILE_ID>
 ```
 
-**Compare file versions:**
+**Upload a file and reference it in a task:**
 
 ```bash
-# Get version history
-$CLI --compact files versions <FILE_ID>
-
-# Read specific version content
-$CLI files version-content <FILE_ID> <VERSION_ID>
+$CLI --compact files upload --project <PROJECT_ID> --file-path /path/to/protocol.md
+# Use the returned file ID:
+$CLI --compact tasks send <TASK_ID> --message "Optimize this protocol" --file-refs "<FILE_ID>" --wait
 ```
 
-**Upload a local file to a project:**
+**Edit-in-place (working copy):**
 
 ```bash
-$CLI --compact files upload --project <PROJECT_ID> --file /path/to/protocol.md
-```
-
-**Fork a protocol to another project:**
-
-```bash
-$CLI --compact files fork <FILE_ID> --target-project <TARGET_PROJECT_ID>
-```
-
-**Edit-in-place workflow (working copy):**
-
-```bash
-# 1. Create working copy
 WC=$($CLI --compact files working-copy <FILE_ID> | jq -r '.id')
-
-# 2. ... make edits externally ...
-
-# 3. Commit the working copy
+# ... make edits externally ...
 $CLI --compact files commit "$WC"
-```
-
-**Reference a file in a task message:**
-
-```bash
-# Use file IDs from files list as --file-refs in tasks send
-$CLI --compact tasks send <TASK_ID> --message "Optimize this protocol" --file-refs "<FILE_ID>"
 ```

--- a/skills/elnora-folders/SKILL.md
+++ b/skills/elnora-folders/SKILL.md
@@ -8,12 +8,12 @@ description: >
 
 # Elnora Folders
 
-Manage the folder tree within Elnora projects. Folders organize files into a hierarchy.
+Manage the folder tree within Elnora projects.
 
 ## Invocation
 
-```
-CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
+```bash
+CLI="elnora"
 ```
 
 ## Commands
@@ -21,23 +21,23 @@ CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
 ### List Folders
 
 ```bash
-$CLI --compact folders list --project <PROJECT_ID>
+$CLI --compact folders list <PROJECT_ID>
 ```
 
-`--project` is required. Returns the folder tree for the project.
+`<PROJECT_ID>` is positional (`projectId`). Returns the folder tree for the project.
 
 ### Create Folder
 
 ```bash
-$CLI --compact folders create --project <PROJECT_ID> --name "Experiments"
-$CLI --compact folders create --project <PROJECT_ID> --name "Sub Folder" --parent <PARENT_FOLDER_ID>
+$CLI --compact folders create <PROJECT_ID> --name "Experiments"
+$CLI --compact folders create <PROJECT_ID> --name "Sub Folder" --parent-id <PARENT_FOLDER_ID>
 ```
 
-| Flag | Required | Notes |
-|------|----------|-------|
-| `--project` | Yes | Project UUID |
+| Flag/Arg | Required | Notes |
+|----------|----------|-------|
+| `<PROJECT_ID>` | Yes | Positional — project UUID |
 | `--name` | Yes | Folder name |
-| `--parent` | No | Parent folder UUID for nesting |
+| `--parent-id` | No | Parent folder UUID for nesting (optional, so it's a flag) |
 
 ### Rename Folder
 
@@ -45,16 +45,14 @@ $CLI --compact folders create --project <PROJECT_ID> --name "Sub Folder" --paren
 $CLI --compact folders rename <FOLDER_ID> --name "New Name"
 ```
 
-`--name` is required.
-
 ### Move Folder
 
 ```bash
-$CLI --compact folders move <FOLDER_ID> --parent <NEW_PARENT_ID>
-$CLI --compact folders move <FOLDER_ID> --parent root
+$CLI --compact folders move <FOLDER_ID> <NEW_PARENT_ID>
+$CLI --compact folders move <FOLDER_ID> root
 ```
 
-`--parent` is required. Use `root` to move to the project root level.
+Both `<FOLDER_ID>` and `<NEW_PARENT_ID>` are positional (`folderId` and `parentId`). Use `root` to move to the project root level.
 
 ### Delete Folder
 
@@ -63,27 +61,22 @@ $CLI --compact folders delete <FOLDER_ID>
 # -> {"deleted":true,"folderId":"<UUID>"}
 ```
 
-Destructive -- confirm with user before running.
+Destructive — confirm with user before running.
 
 ## Agent Recipes
 
-**Set up a folder structure for a new project:**
+**Set up folder structure for a new project:**
 
 ```bash
 PROJECT="<PROJECT_ID>"
-
-# Create top-level folders
-$CLI --compact folders create --project "$PROJECT" --name "Protocols"
-$CLI --compact folders create --project "$PROJECT" --name "Data"
-$CLI --compact folders create --project "$PROJECT" --name "Reports"
+$CLI --compact folders create "$PROJECT" --name "Protocols"
+$CLI --compact folders create "$PROJECT" --name "Data"
+$CLI --compact folders create "$PROJECT" --name "Reports"
 ```
 
 **Move a file into a folder:**
 
 ```bash
-# List folders to get the target ID
-$CLI --compact folders list --project <PROJECT_ID>
-
-# Update the file's folder
+$CLI --compact folders list <PROJECT_ID>
 $CLI --compact files update <FILE_ID> --folder <FOLDER_ID>
 ```

--- a/skills/elnora-orgs/SKILL.md
+++ b/skills/elnora-orgs/SKILL.md
@@ -14,8 +14,8 @@ Manage organizations, members, billing, invitations, and the shared organization
 
 ## Invocation
 
-```
-CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
+```bash
+CLI="elnora"
 ```
 
 ## Organization Commands
@@ -26,15 +26,11 @@ CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
 $CLI --compact orgs list
 ```
 
-Lists all organizations the current user belongs to.
-
 ### Get Organization
 
 ```bash
 $CLI --compact orgs get <ORG_ID>
 ```
-
-Returns organization details by ID.
 
 ### Create Organization
 
@@ -42,11 +38,6 @@ Returns organization details by ID.
 $CLI --compact orgs create --name "Elnora Bio Lab"
 $CLI --compact orgs create --name "Elnora Bio Lab" --description "Main research org"
 ```
-
-| Flag | Required | Notes |
-|------|----------|-------|
-| `--name` | Yes | Organization name |
-| `--description` | No | Organization description |
 
 ### Update Organization
 
@@ -69,16 +60,16 @@ $CLI --compact orgs members <ORG_ID>
 $CLI --compact orgs update-role <ORG_ID> <MEMBERSHIP_ID> --role Admin
 ```
 
-`--role` is required. Uses the membership ID (not user ID).
+Both positional. `--role` is required. Uses the **membership ID** (not user ID) — get it from `orgs members`.
 
 ### Remove Member
 
 ```bash
 $CLI --compact orgs remove-member <ORG_ID> <MEMBERSHIP_ID>
-# -> {"deleted":true,"membershipId":"...","orgId":"..."}
+# -> {"removed":true}
 ```
 
-Destructive -- confirm with user first.
+Both positional. Destructive — confirm with user first.
 
 ### Get Billing
 
@@ -86,33 +77,28 @@ Destructive -- confirm with user first.
 $CLI --compact orgs billing <ORG_ID>
 ```
 
-Returns billing information for the organization.
-
-### List All Org Files (Admin Compliance View)
+### List Org Files (Admin Compliance View)
 
 ```bash
-$CLI --compact orgs files --org <ORG_ID>
-$CLI --compact orgs files --org <ORG_ID> --page 2 --page-size 50
+$CLI --compact orgs files <ORG_ID>
+$CLI --compact orgs files <ORG_ID> --page 2 --page-size 50
 ```
 
-`--org` is required. Lists all files across all projects in the organization. Useful for admin compliance and auditing.
+`<ORG_ID>` is positional (`orgId`). Lists all files across all projects in the organization.
 
 ### Set Default Organization
 
 ```bash
 $CLI --compact orgs set-default <ORG_ID>
-# -> {"updated":true,"defaultOrgId":"<UUID>"}
 ```
-
-Sets the specified organization as your default. Used when no `--profile` is specified.
 
 ### Set Stripe Customer ID (SystemAdmin)
 
 ```bash
-$CLI --compact orgs set-stripe <ORG_ID> --customer-id cus_xxx
+$CLI --compact orgs set-stripe <ORG_ID> <CUSTOMER_ID>
 ```
 
-SystemAdmin only. Sets the Stripe billing customer ID for an organization.
+Both positional. Example: `elnora --compact orgs set-stripe <ORG_ID> cus_xxx`
 
 ### List All Organizations (SystemAdmin)
 
@@ -120,9 +106,7 @@ SystemAdmin only. Sets the Stripe billing customer ID for an organization.
 $CLI --compact orgs list-all
 ```
 
-SystemAdmin only. Lists ALL organizations on the platform (not just the user's).
-
-### Delete Organization (SystemAdmin)
+### Delete Organization
 
 ```bash
 $CLI --compact orgs delete <ORG_ID>
@@ -130,8 +114,7 @@ $CLI --compact orgs delete <ORG_ID> --yes
 # -> {"deleted":true,"orgId":"<UUID>"}
 ```
 
-**DANGEROUS: Permanently deletes the organization and ALL its data. Irreversible.**
-Requires typing the organization name to confirm. Use `--yes` to skip (non-interactive/CI only).
+**DANGEROUS.** Requires y/N confirmation. Use `--yes` to skip (non-interactive/CI only).
 
 ## Invitation Commands
 
@@ -141,11 +124,6 @@ Requires typing the organization name to confirm. Use `--yes` to skip (non-inter
 $CLI --compact orgs invite <ORG_ID> --email user@example.com
 $CLI --compact orgs invite <ORG_ID> --email user@example.com --role Admin
 ```
-
-| Flag | Required | Notes |
-|------|----------|-------|
-| `--email` | Yes | Email to invite |
-| `--role` | No | Role for invitee (default: "Member") |
 
 ### List Pending Invitations
 
@@ -157,24 +135,26 @@ $CLI --compact orgs invitations <ORG_ID>
 
 ```bash
 $CLI --compact orgs cancel-invite <ORG_ID> <INVITATION_ID>
-# -> {"deleted":true,"invitationId":"...","orgId":"..."}
+# -> {"cancelled":true,"invitationId":"..."}
 ```
+
+Both positional.
 
 ### Get Invitation Info (by token)
 
 ```bash
-$CLI --compact orgs invitation-info <TOKEN>
+$CLI --compact orgs invitation-info --token <TOKEN>
 ```
 
-Returns details about an invitation using its token string.
+`--token` is a flag (not positional — `token` doesn't end in "Id").
 
 ### Accept Invitation
 
 ```bash
-$CLI --compact orgs accept-invite <TOKEN>
+$CLI --compact orgs accept-invite --token <TOKEN>
 ```
 
-Accepts an invitation using its token.
+`--token` is a flag.
 
 ## Organization Library Commands
 
@@ -187,7 +167,7 @@ $CLI --compact library files --org <ORG_ID>
 $CLI --compact library files --org <ORG_ID> --page 2 --page-size 50
 ```
 
-`--org` is required.
+`--org` is a flag (`org` doesn't end in "Id").
 
 ### List Library Folders
 
@@ -208,6 +188,8 @@ $CLI --compact library create-folder --org <ORG_ID> --name "Sub Folder" --parent
 $CLI --compact library rename-folder --org <ORG_ID> <FOLDER_ID> --name "New Name"
 ```
 
+`<FOLDER_ID>` is positional (`folderId`). `--org` and `--name` are flags.
+
 ### Delete Library Folder
 
 ```bash
@@ -215,7 +197,7 @@ $CLI --compact library delete-folder --org <ORG_ID> <FOLDER_ID>
 # -> {"deleted":true,"folderId":"..."}
 ```
 
-Destructive -- confirm with user first.
+Destructive — confirm with user first.
 
 ## Agent Recipes
 
@@ -226,7 +208,7 @@ ORG=$($CLI --compact orgs list | jq -r 'if type == "array" then .[0].id else .it
 $CLI --compact orgs billing "$ORG"
 ```
 
-**Invite a new team member:**
+**Invite a team member:**
 
 ```bash
 $CLI --compact orgs invite <ORG_ID> --email new.researcher@lab.com --role Member
@@ -235,7 +217,6 @@ $CLI --compact orgs invite <ORG_ID> --email new.researcher@lab.com --role Member
 **Browse shared library:**
 
 ```bash
-# List folders, then list files
 $CLI --compact library folders --org <ORG_ID>
 $CLI --compact library files --org <ORG_ID>
 ```

--- a/skills/elnora-platform/SKILL.md
+++ b/skills/elnora-platform/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: elnora-platform
 description: >
-  This skill should be used when the user asks about "Elnora platform", "elnora CLI",
+  Use when the user asks about "Elnora platform", "elnora CLI",
   "platform API", "elnora projects", "elnora tasks", "elnora files", "protocol generation",
   "platform search", "elnora orgs", "elnora folders", "elnora admin", "API keys",
   "elnora health", "elnora auth", or any task involving the Elnora AI Platform.
@@ -14,8 +14,8 @@ Route Elnora Platform queries to the correct sub-skill. Load only what is needed
 
 ## Invocation
 
-```
-CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
+```bash
+CLI="elnora"
 ```
 
 Global flags go BEFORE the subcommand:
@@ -29,18 +29,19 @@ $CLI projects list --compact            # WRONG -- fails
 
 | Flag | Effect |
 |------|--------|
-| `--compact` | Minified JSON -- always use for agent workflows |
+| `--compact` | Minified JSON — always use for agent workflows |
 | `--output <json\|csv>` | Output format (default: json) |
 | `--fields "id,name"` | Return only these fields |
-| `--profile <name>` | Named profile to use (default: `default`). Set with `auth login --profile` |
+| `--profile <name>` | Named profile (default: `default`). Set with `auth login --api-key <KEY> --profile <name>` |
+| `--json` | Force JSON output |
 
 ## Auth
 
-Requires `ELNORA_API_KEY` in `.env` (prefix: `elnora_live_`). Also accepts `ELNORA_MCP_API_KEY`.
+Requires `ELNORA_API_KEY` environment variable (prefix: `elnora_live_`), `ELNORA_MCP_API_KEY`, or a saved profile in `~/.elnora/profiles.toml`.
 
 ```bash
 $CLI --compact auth status
-# -> {"authenticated":true,"totalProjects":N}
+# -> {"profile":"default","authenticated":true,"projectCount":N}
 ```
 
 Get keys: platform.elnora.ai > Settings > API Keys
@@ -59,11 +60,23 @@ Get keys: platform.elnora.ai > Settings > API Keys
 | Feature flags (SystemAdmin) | `elnora-admin` | feature flag, flags, set flag, list flags |
 | What can the Elnora Agent do? (tools, search, memory) | `elnora-agent` | agent capabilities, agent tools, what can agent do |
 
+## Positional Argument Convention
+
+Required string fields ending in `Id` (e.g. `taskId`, `projectId`, `fileId`) become positional arguments. Everything else becomes a flag.
+
+```bash
+elnora tasks get <task-id>              # taskId -> positional
+elnora tasks list --project <UUID>      # project -> flag (doesn't end in "Id")
+elnora files fork <file-id> --target-project <UUID>  # fileId -> positional, targetProject -> flag
+```
+
+**Rule:** positional if and only if the field is: required + not boolean + no enum choices + key ends in "Id".
+
 ## ID Format
 
 All IDs are UUIDs: `bfdc6fbd-40ed-4042-9ea7-c79a5ec90085`. Invalid format exits 1 with a suggestion showing the correct list command.
 
-Exception: `account get` and `account update` use **integer** user IDs (e.g. `42`), not UUIDs.
+Exception: `account get` and `account update` use `userId` which accepts any string (typically an integer like `42`).
 
 ## Pagination
 
@@ -87,12 +100,12 @@ Errors -> stderr, exit code > 0:
 
 | Code | Exit | Action |
 |------|------|--------|
-| `AUTH_FAILED` | 3 | Check ELNORA_API_KEY in .env |
+| `AUTH_FAILED` | 3 | Check ELNORA_API_KEY env var or profile |
 | `NOT_FOUND` | 4 | Verify the UUID |
 | `VALIDATION_ERROR` | 2 | Check parameters |
 | `RATE_LIMITED` | 5 | Wait and retry (see Rate Limits below) |
 | `SERVER_ERROR` | 6 | Retry later |
-| `INTERNAL_ERROR` | 1 | Unexpected — report bug |
+| `ELNORA_ERROR` | 1 | Unexpected — report bug |
 
 ## Rate Limits
 
@@ -124,14 +137,10 @@ HTTP 429 on limit. Check the `Retry-After` header for seconds to wait.
 Projects contain tasks and files. Typical flow:
 
 1. `projects list` -> get project ID
-2. `tasks list --project <ID>` -> get task ID
-3. `tasks messages <ID>` -> read conversation
-4. `tasks send <ID> --message "..."` -> send message (returns user echo only)
-5. **Poll `tasks messages <ID>`** every 5-10s until last message is `role: "assistant"` with `metadata.status: "completed"` -> AI response ready
-6. `files list --project <ID>` -> browse generated outputs
-7. `files content <FILE_ID>` -> read a protocol file
-
-**Important:** Steps 4-5 apply to all message sending (send, create with message, generate protocol). The backend is fire-and-forget — AI responses are never returned inline. See `elnora-tasks` skill for full polling details.
+2. `tasks create --project <ID> --message "..."` -> create task with initial prompt
+3. `tasks send <TASK_ID> --message "..." --wait` -> send message and wait for response
+4. `files list --project <ID>` -> browse generated outputs
+5. `files content <FILE_ID>` -> read a protocol file
 
 ## All Command Groups
 
@@ -141,14 +150,18 @@ elnora api-keys     Manage API keys and creation policy
 elnora audit        View audit logs
 elnora auth         Manage authentication
 elnora completion   Generate shell completion script
+elnora doctor       Run diagnostics (API, auth, version, config checks)
 elnora feedback     Submit feedback
 elnora files        Manage project files (incl. batch upload)
 elnora flags        Manage global feature flags (SystemAdmin)
 elnora folders      Manage project folders
 elnora health       Check platform reachability
 elnora library      Manage organization library
+elnora mcp          Run as MCP server (--http or --stdio)
+elnora open         Open platform pages in browser
 elnora orgs         Manage organizations (incl. set-default, delete, list-all)
 elnora projects     Manage projects
 elnora search       Search tasks, files, and file content
 elnora tasks        Manage tasks
+elnora whoami       Show current profile and org
 ```

--- a/skills/elnora-projects/SKILL.md
+++ b/skills/elnora-projects/SKILL.md
@@ -13,8 +13,8 @@ Manage projects on the Elnora AI Platform. Projects are containers for tasks, fi
 
 ## Invocation
 
-```
-CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
+```bash
+CLI="elnora"
 ```
 
 ## Commands
@@ -27,13 +27,11 @@ $CLI --compact projects list --page 2 --page-size 50
 $CLI --compact --fields "id,name" projects list
 ```
 
-Response shape:
+Response:
 
 ```json
-{"items":[{"id":"<UUID>","name":"...","description":"...","icon":"...","isDefault":false,"isArchived":false,"memberCount":1,"myRole":"owner","createdAt":"...","updatedAt":"..."}],"page":1,"pageSize":25,"totalCount":N,"totalPages":N,"hasNextPage":false}
+{"items":[{"id":"<UUID>","name":"...","description":"...","isDefault":false,"isArchived":false,"memberCount":1,"myRole":"owner","createdAt":"..."}],"page":1,"totalCount":N,"hasNextPage":false}
 ```
-
-Key fields: `id` (needed for all other commands), `name`, `memberCount`, `myRole`.
 
 ### Get Project
 
@@ -41,13 +39,7 @@ Key fields: `id` (needed for all other commands), `name`, `memberCount`, `myRole
 $CLI --compact projects get <PROJECT_ID>
 ```
 
-Returns project detail with `members` array:
-
-```json
-{"members":[{"id":"<UUID>","userId":N,"email":"...","displayName":"...","role":"owner","createdAt":"..."}],"id":"<UUID>","name":"...","description":"...","icon":"...","memberCount":1,"myRole":"owner"}
-```
-
-Use this to check membership and roles before performing operations.
+Returns project detail with `members` array.
 
 ### Create Project
 
@@ -61,17 +53,14 @@ $CLI --compact projects create --name "Protocol Lab" --description "PCR protocol
 | `--description` | No | Project description |
 | `--icon` | No | Project icon |
 
-Returns the created project object with its new `id`.
-
 ### Update Project
 
 ```bash
 $CLI --compact projects update <PROJECT_ID> --name "New Name"
 $CLI --compact projects update <PROJECT_ID> --description "Updated description"
-$CLI --compact projects update <PROJECT_ID> --name "New" --description "Desc" --icon "new-icon"
 ```
 
-Must provide at least one of `--name`, `--description`, or `--icon`. Exits 1 with suggestion if none given.
+Must provide at least one of `--name`, `--description`, or `--icon`.
 
 ### Archive Project
 
@@ -80,7 +69,7 @@ $CLI --compact projects archive <PROJECT_ID>
 # -> {"archived":true,"projectId":"<UUID>"}
 ```
 
-Destructive operation — confirm with user before running.
+Destructive — confirm with user before running.
 
 ### List Members
 
@@ -88,35 +77,30 @@ Destructive operation — confirm with user before running.
 $CLI --compact projects members <PROJECT_ID>
 ```
 
-Returns the list of members and their roles for a project.
-
 ### Add Member
 
 ```bash
-$CLI --compact projects add-member <PROJECT_ID> --user-id <USER_UUID> --role Member
+$CLI --compact projects add-member <PROJECT_ID> <USER_ID> --role Member
 ```
 
-| Flag | Required | Notes |
-|------|----------|-------|
-| `--user-id` | Yes | User UUID to add |
-| `--role` | No | Role to assign (default: "Member") |
+Both `<PROJECT_ID>` and `<USER_ID>` are positional (`projectId` and `userId`). `--role` defaults to "Member".
 
 ### Update Member Role
 
 ```bash
-$CLI --compact projects update-role <PROJECT_ID> <USER_UUID> --role Admin
+$CLI --compact projects update-role <PROJECT_ID> <USER_ID> --role Admin
 ```
 
-`--role` is required.
+Both positional. `--role` is required.
 
 ### Remove Member
 
 ```bash
-$CLI --compact projects remove-member <PROJECT_ID> <USER_UUID>
-# -> {"removed":true,"projectId":"<UUID>","userId":"<UUID>"}
+$CLI --compact projects remove-member <PROJECT_ID> <USER_ID>
+# -> {"removed":true}
 ```
 
-Destructive — confirm with user before running.
+Both positional. Destructive — confirm with user before running.
 
 ### Leave Project
 
@@ -128,25 +112,15 @@ Removes the current user from the project.
 
 ## Agent Recipes
 
-**Get the default project ID quickly:**
+**Get the default project ID:**
 
 ```bash
 $CLI --compact --fields "id,name" projects list --page-size 5
 ```
 
-**Check if a project exists by name before creating:**
-
-```bash
-$CLI --compact --fields "id,name" projects list
-# scan results — if not found, create it
-```
-
 **Full project setup with members:**
 
 ```bash
-# 1. Create project
 PROJECT=$($CLI --compact projects create --name "New Lab" | jq -r '.id')
-
-# 2. Add a team member
-$CLI --compact projects add-member "$PROJECT" --user-id <USER_UUID> --role Member
+$CLI --compact projects add-member "$PROJECT" <USER_ID> --role Member
 ```

--- a/skills/elnora-search/SKILL.md
+++ b/skills/elnora-search/SKILL.md
@@ -5,17 +5,17 @@ description: >
   "search files", "search file content", "search inside files", "find tasks about",
   "query Elnora", "search Elnora platform", "full text search",
   or any task involving searching the Elnora Platform for tasks, files, or all resources
-  by keyword. NOT for web search — use elnora-agent-search for that.
+  by keyword. NOT for web search — use elnora-agent for that.
 ---
 
 # Elnora Search
 
-Search tasks, files, or all resources across all projects by keyword query.
+Search tasks, files, or all resources across projects by keyword.
 
 ## Invocation
 
-```
-CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
+```bash
+CLI="elnora"
 ```
 
 ## Commands
@@ -27,15 +27,11 @@ $CLI --compact search tasks --query "PCR protocol"
 $CLI --compact search tasks --query "BRCA1" --page-size 10
 ```
 
-Returns paginated results with relevance ranking:
+Results include `snippet` with HTML-bold match highlights and `rank` for relevance:
 
 ```json
-{"items":[{"type":"task","id":"<UUID>","title":"...","snippet":"...with <b>highlighted</b> matches...","projectId":"<UUID>","createdAt":"...","rank":0.06}],"page":1,"totalCount":N,"hasNextPage":false}
+{"items":[{"type":"task","id":"<UUID>","title":"...","snippet":"...with <b>highlighted</b> matches...","projectId":"<UUID>","rank":0.06}],"page":1,"totalCount":N,"hasNextPage":false}
 ```
-
-Results include `snippet` with HTML-bold match highlights and `rank` for relevance sorting.
-
-Use task IDs from results with `tasks get` or `tasks messages` to read full conversations.
 
 ### Search Files
 
@@ -44,17 +40,16 @@ $CLI --compact search files --query "gel electrophoresis"
 $CLI --compact search files --query "template" --page 2
 ```
 
-Same pagination shape. Use file IDs from results with `files get` or `files content`.
-
 ### Search File Content
 
 ```bash
 $CLI --compact search file-content --query "annealing temperature"
-$CLI --compact search file-content --query "BRCA1" --project <PROJECT_ID>
-$CLI --compact files search-content -q "gel electrophoresis" --page-size 10
+$CLI --compact search file-content --query "BRCA1" --project-id <PROJECT_ID>
 ```
 
-Full-text search inside file contents. Optional `--project` filter to limit to a specific project. Also available as `files search-content`.
+Full-text search inside file contents. Also available as `files search-content` (which uses `--project` instead of `--project-id`).
+
+Note: `search file-content` uses `--project-id` (field name: `projectId`, optional so it's a flag). `files search-content` uses `--project` (field name: `project`).
 
 ### Search All
 
@@ -63,9 +58,9 @@ $CLI --compact search all --query "BRCA1"
 $CLI --compact search all --query "transfection" --page-size 50
 ```
 
-Searches both tasks and files in a single call. Results include a `type` field ("task" or "file") to distinguish.
+Searches both tasks and files. Results include a `type` field ("task" or "file").
 
-## Options
+## Shared Options
 
 All four commands share:
 
@@ -77,20 +72,14 @@ All four commands share:
 
 ## Agent Recipes
 
-**Find a task by protocol name, then read it:**
+**Find a task, then read it:**
 
 ```bash
 TASK_ID=$($CLI --compact search tasks --query "BRCA1" | jq -r '.items[0].id')
 $CLI --compact tasks messages "$TASK_ID"
 ```
 
-**Find all files matching a keyword:**
-
-```bash
-$CLI --compact --fields "id,name" search files --query "PCR"
-```
-
-**Broad search across everything:**
+**Broad search:**
 
 ```bash
 $CLI --compact search all --query "HEK 293"

--- a/skills/elnora-tasks/SKILL.md
+++ b/skills/elnora-tasks/SKILL.md
@@ -9,27 +9,28 @@ description: >
 
 # Elnora Tasks
 
-Tasks are conversations with the Elnora AI Platform. Send messages to generate protocols, iterate on outputs, and reference uploaded files.
+Tasks are conversations with the Elnora AI Agent. Send messages to generate protocols, iterate on outputs, and reference uploaded files.
 
-## CRITICAL: Async Response Pattern (CLI and MCP)
+## Response Retrieval
 
-The Elnora backend uses fire-and-forget architecture. When you send a message (via CLI `tasks send`, MCP `elnora_send_message`, `elnora_generate_protocol`, or `elnora_create_task` with initial_message), **the AI response is NOT returned in the response**. You only get back the user message echo.
+The Elnora backend processes agent responses asynchronously. When you send a message, the POST returns immediately with the user message echo — the AI response arrives separately.
 
-**You MUST poll for the AI response:**
+The CLI provides three modes for retrieving agent responses:
 
-1. After sending, wait **5 seconds**
-2. Call `tasks messages <TASK_ID>` (CLI) or `elnora_get_task_messages` (MCP)
-3. Check if the **last message** has `role: "assistant"`
-4. If still `role: "user"` → wait **10 seconds**, poll again
-5. When `role: "assistant"` and `metadata.status: "completed"` → response is ready
-6. **Timeout after 5 minutes** (platform processing limit is 300s)
+| Mode | Flag | Behavior | Timeout |
+|------|------|----------|---------|
+| Fire-and-forget | _(default)_ | Returns immediately, no response | — |
+| Polling | `--wait` | Auto-polls every 2s until assistant message appears | 120s |
+| Streaming | `--stream` | Real-time SSE token-by-token output | 300s |
 
-This applies to ALL response retrieval — there is no streaming or push channel for CLI/MCP clients. Known issue: ELN-495, ELN-496.
+**MCP mode** (`elnora_tasks_send`): Always collects the full response automatically via streaming, with polling as fallback. The caller receives `{ sent, taskId, response }` with the complete assistant content.
+
+**Recommended:** Use `--wait` for simple interactions, `--stream` for long responses where you want real-time output.
 
 ## Invocation
 
-```
-CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
+```bash
+CLI="elnora"
 ```
 
 ## Commands
@@ -37,17 +38,14 @@ CLI="uv run --project ${CLAUDE_PLUGIN_ROOT} elnora"
 ### List Tasks
 
 ```bash
-# All tasks
 $CLI --compact tasks list
-
-# Tasks in a specific project
 $CLI --compact tasks list --project <PROJECT_ID>
-
-# Paginate
 $CLI --compact tasks list --project <PROJECT_ID> --page 2 --page-size 50
 ```
 
-Response — each task has `id`, `title`, `status`, `messageCount`:
+Pagination: `--page` (default 1), `--page-size` (default 25, max 100).
+
+Response:
 
 ```json
 {"items":[{"id":"<UUID>","projectId":"<UUID>","title":"...","status":"active","messageCount":4,"lastMessageAt":"...","createdAt":"..."}],"page":1,"totalCount":N,"hasNextPage":false}
@@ -59,7 +57,7 @@ Response — each task has `id`, `title`, `status`, `messageCount`:
 $CLI --compact tasks get <TASK_ID>
 ```
 
-Returns full task detail including `messages` array and `fileReferences`. Use this instead of separate `messages` call when the full context is needed in one shot.
+Returns full task detail. Use this to inspect a task before interacting.
 
 ### Create Task
 
@@ -73,13 +71,19 @@ $CLI --compact tasks create --project <PROJECT_ID> --title "PCR protocol for BRC
 | `--title` | No | Task title (auto-generated if omitted) |
 | `--message` | No | Initial message to start the conversation |
 
-Returns the created task with its `id`. Use this ID for subsequent `send` and `messages` calls.
+Returns the created task with its `id`. If `--message` is provided, the agent will process it asynchronously — use `tasks send --wait` or `tasks messages` to retrieve the response.
 
 ### Send Message
 
 ```bash
-# Simple message
+# Fire-and-forget (returns immediately)
 $CLI --compact tasks send <TASK_ID> --message "Use Taq polymerase and set annealing to 58C"
+
+# Wait for agent response (polls until complete, 120s timeout)
+$CLI --compact tasks send <TASK_ID> --message "Use Taq polymerase" --wait
+
+# Stream response in real-time via SSE
+$CLI --compact tasks send <TASK_ID> --message "Use Taq polymerase" --stream
 
 # Reference uploaded files
 $CLI --compact tasks send <TASK_ID> --message "Optimize based on this template" --file-refs "<FILE_ID_1>,<FILE_ID_2>"
@@ -89,10 +93,12 @@ $CLI --compact tasks send <TASK_ID> --message "Optimize based on this template" 
 |------|----------|-------|
 | `--message` | Yes | Message content |
 | `--file-refs` | No | Comma-separated file UUIDs to attach as context |
+| `--wait` | No | Poll for agent response (120s timeout) |
+| `--stream` | No | Stream agent response in real-time via SSE |
 
-Returns the created message object.
+**Streaming details:** Status events (thinking, tool use) go to stderr, content tokens go to stdout. This makes streaming pipeable: `elnora tasks send ... --stream > response.txt`.
 
-**Async processing:** After `send`, the Elnora agent processes your message asynchronously. The response is NOT immediate — you must poll `messages` to check for the assistant reply. See [Waiting for Responses](#waiting-for-responses) below.
+SSE event types: `think`, `tool_start`, `tool_end`, `progress`, `token`, `completed`, `error`, `timeout`.
 
 ### Get Messages
 
@@ -105,87 +111,67 @@ $CLI --compact tasks messages <TASK_ID> --cursor <CURSOR>
 Response — messages ordered by `sequence`, with `role` (user/assistant):
 
 ```json
-{"items":[{"id":"<UUID>","role":"user","content":"...","sequence":1,"createdAt":"...","attachments":[]},{"id":"<UUID>","role":"assistant","content":"...","metadata":"{\"status\":\"completed\"}","sequence":2,"createdAt":"...","attachments":[]}],"nextCursor":null,"hasMore":false}
+{"items":[{"id":"<UUID>","role":"user","content":"...","sequence":1,"createdAt":"..."},{"id":"<UUID>","role":"assistant","content":"...","metadata":"{\"status\":\"completed\"}","sequence":2,"createdAt":"..."}],"nextCursor":null,"hasMore":false}
 ```
 
-Cursor-based pagination: if `hasMore` is true, pass `nextCursor` as `--cursor`.
+Cursor-based pagination: if `hasMore` is true, pass `nextCursor` as `--cursor`. Default limit is 50 (max 100).
 
 ### Update Task
 
 ```bash
 $CLI --compact tasks update <TASK_ID> --title "Updated title"
 $CLI --compact tasks update <TASK_ID> --status completed
-$CLI --compact tasks update <TASK_ID> --title "New name" --status completed
 ```
 
-Must provide at least one of `--title` or `--status`. Exits 1 with suggestion if neither is given.
+Must provide at least one of `--title` or `--status`.
 
 ### Archive Task
 
 ```bash
 $CLI --compact tasks archive <TASK_ID>
-# → {"archived":true,"taskId":"<UUID>"}
+# -> {"archived":true,"taskId":"<UUID>"}
 ```
 
-Destructive operation — confirm with user before running.
+Destructive — confirm with user before running.
 
-## Waiting for Responses
+## MCP Tool Names
 
-After `tasks send` or `tasks create --message`, the Elnora agent processes asynchronously. There is no streaming via the CLI — you must poll.
+All commands are auto-registered as MCP tools with the `elnora_` prefix:
 
-**How to poll:**
+| CLI command | MCP tool name |
+|-------------|---------------|
+| `tasks list` | `elnora_tasks_list` |
+| `tasks get` | `elnora_tasks_get` |
+| `tasks create` | `elnora_tasks_create` |
+| `tasks send` | `elnora_tasks_send` |
+| `tasks messages` | `elnora_tasks_messages` |
+| `tasks update` | `elnora_tasks_update` |
+| `tasks archive` | `elnora_tasks_archive` |
 
-```bash
-# Poll until the last message is from the assistant with status "completed"
-LAST=$($CLI --compact tasks messages <TASK_ID> | jq '.items[-1]')
-echo "$LAST" | jq '{role: .role, status: (.metadata | fromjson? // {} | .status)}'
-# → {"role":"assistant","status":"completed"}  ← ready
-# → {"role":"user","status":null}              ← still processing, wait and retry
-```
-
-**Status values** in assistant message `metadata`:
-
-| `metadata.status` | Meaning |
-|-------------------|---------|
-| `"completed"` | Agent finished successfully — read `.content` for the response |
-| `"error"` | Agent encountered an error — `.metadata` may contain `error_type` |
-
-**Polling strategy:**
-1. Wait **5 seconds** after sending, then poll `tasks messages`
-2. Check if the last message has `role: "assistant"`
-3. If not, wait **10 seconds** and poll again (responses can take seconds to several minutes for complex multi-tool protocols)
-4. **Timeout after 5 minutes** — the platform's own processing timeout is 300 seconds
-
-**No intermediate statuses** — messages jump directly to `completed` or `error` once the agent finishes. If the last message is still `role: "user"`, the agent hasn't responded yet.
+MCP tools accept the same parameters as CLI flags (camelCase). `elnora_tasks_send` always waits for the full agent response.
 
 ## Agent Recipes
 
-**Full protocol generation flow with polling:**
+**Full protocol generation with --wait:**
 
 ```bash
-# 1. Find or create project
 PROJECT=$($CLI --compact --fields "id" projects list | jq -r '.items[0].id')
-
-# 2. Create task with initial prompt
 TASK=$($CLI --compact tasks create --project "$PROJECT" --title "PCR BRCA1" --message "Generate PCR protocol for BRCA1 exon 11" | jq -r '.id')
-
-# 3. Poll for assistant response
-sleep 5
-while true; do
-  LAST_ROLE=$($CLI --compact tasks messages "$TASK" | jq -r '.items[-1].role')
-  [ "$LAST_ROLE" = "assistant" ] && break
-  sleep 10
-done
-
-# 4. Read the completed response
-$CLI --compact tasks messages "$TASK" | jq '.items[-1].content'
-
-# 5. Iterate
-$CLI --compact tasks send "$TASK" --message "Add gel electrophoresis verification step"
+$CLI --compact tasks send "$TASK" --message "Add gel electrophoresis step" --wait
 ```
 
-**Check latest assistant response only:**
+**Read latest assistant response:**
 
 ```bash
-$CLI --compact tasks messages <TASK_ID> | jq '.items[-1] | {role, content, status: (.metadata | fromjson? // {} | .status)}'
+$CLI --compact tasks messages <TASK_ID> | jq '.items[-1] | select(.role == "assistant") | .content'
+```
+
+**Manual polling (custom timeout/retry):**
+
+```bash
+# Poll until the last message is from the assistant
+LAST=$($CLI --compact tasks messages <TASK_ID> | jq '.items[-1]')
+echo "$LAST" | jq '{role: .role, status: (.metadata | fromjson? // {} | .status)}'
+# -> {"role":"assistant","status":"completed"}  <- ready
+# -> {"role":"user","status":null}              <- still processing
 ```


### PR DESCRIPTION
## Summary
- Rewrote all 9 skill files (`elnora-admin`, `elnora-agent`, `elnora-files`, `elnora-folders`, `elnora-orgs`, `elnora-platform`, `elnora-projects`, `elnora-search`, `elnora-tasks`) to accurately reflect the TypeScript CLI architecture
- Replaced Python-era invocation patterns (`uv run --project`) with direct `elnora` CLI calls
- Verified every command, flag, positional argument, and response format against actual Zod schemas and Commander.js adapter source code
- Fixed factual errors: health exit code (1 not 6), error code naming (`ELNORA_ERROR` not `INTERNAL_ERROR`), auth references (env var/profiles.toml not `.env`), download/content endpoint distinction

## Test plan
- [ ] Verify skill files render correctly as Claude Code skill documentation
- [ ] Spot-check CLI commands documented in skills against `elnora --help` output
- [ ] Confirm no remaining Python-era references (`uv run`, `click`, `.py` imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)