### PR TITLE
fix: use org PAT for Homebrew and skills sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: Elnora-AI/homebrew-cli
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.DEPENDABOT_PAT }}
 
       - name: Extract version from tag
         run: |
@@ -170,7 +170,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: Elnora-AI/elnora-plugins
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.DEPENDABOT_PAT }}
           path: elnora-plugins
 
       - name: Sync skills


### PR DESCRIPTION
Switched the token to push to homebrew-cli.