### PR TITLE
feat(tasks): auto-resolve default project when --project is omitted

### DIFF
--- a/__tests__/commands/tasks/tasks.test.ts
+++ b/__tests__/commands/tasks/tasks.test.ts
@@ -131,9 +131,10 @@ describe("tasks.create", () => {
 		expect(tasksCreate.group).toBe("tasks");
 	});
 
-	test("requires project UUID", () => {
-		expect(() => tasksCreate.inputSchema.parse({})).toThrow();
+	test("rejects invalid project UUID but allows omission", () => {
 		expect(() => tasksCreate.inputSchema.parse({ project: "not-uuid" })).toThrow();
+		const noProject = tasksCreate.inputSchema.parse({});
+		expect(noProject.project).toBeUndefined();
 	});
 
 	test("accepts project with optional title and message", () => {

--- a/__tests__/lib/prompt.test.ts
+++ b/__tests__/lib/prompt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 describe("promptSecret", () => {
 	test("module exports promptSecret function", async () => {
@@ -11,7 +11,6 @@ describe("promptSecret", () => {
 
 		// Save originals
 		const origStdin = process.stdin;
-		const origIsTTY = process.stdin.isTTY;
 
 		// Create a readable stream that emits a line
 		const mockStdin = new Readable({

--- a/skills/elnora-tasks/SKILL.md
+++ b/skills/elnora-tasks/SKILL.md
@@ -38,7 +38,13 @@ SSE event types:
 | `error` | `content` | stderr | Pipeline error, client must close |
 | `timeout` | — | stderr | 300s inactivity, client must close |
 
-**IMPORTANT — Always show the full response:** When Elnora returns a response (protocol, literature review, analysis, etc.), print the **entire** assistant content back to the user. No truncation, no summarization, no "here are the key points." The user asked Elnora to generate something — show them everything Elnora said, including comments, suggestions, warnings, and explanations. Strip JSON wrapper/metadata but preserve all human-readable content.
+**IMPORTANT — Communicate everything back to the user in real time.** When streaming, relay all events as they arrive — not just the final response:
+- `think` events: tell the user what Elnora is thinking/planning (e.g., "Elnora is planning the protocol structure...")
+- `tool_start`/`tool_end` events: tell the user which tools Elnora is using (e.g., "Elnora is searching the literature...", "Literature search complete.")
+- `progress` events: relay any intermediate status updates verbatim
+- `token` events: show the streamed content as it arrives
+
+When the full response is complete, print the **entire** assistant content back to the user. No truncation, no summarization, no "here are the key points." The user asked Elnora to generate something — show them everything Elnora said, including comments, suggestions, warnings, and explanations. Strip JSON wrapper/metadata but preserve all human-readable content.
 
 ## Invocation
 
@@ -75,18 +81,28 @@ Returns full task detail. Use this to inspect a task before interacting.
 ### Create Task
 
 ```bash
+# Uses default project automatically
+$CLI --compact tasks create --title "PCR protocol for BRCA1" --message "Generate a simple PCR protocol for BRCA1 exon 11"
+
+# Or specify a project explicitly
 $CLI --compact tasks create --project <PROJECT_ID> --title "PCR protocol for BRCA1" --message "Generate a simple PCR protocol for BRCA1 exon 11"
 ```
 
 | Flag | Required | Notes |
 |------|----------|-------|
-| `--project` | Yes | Project UUID |
+| `--project` | No | Project UUID (uses default project if omitted) |
 | `--title` | No | Task title (auto-generated if omitted) |
 | `--message` | No | Initial message to start the conversation |
 | `--stream` | No | Stream agent response in real-time via SSE (300s timeout). Requires `--message` |
 | `--wait` | No | Poll for agent response (120s timeout). Requires `--message` |
 
 Returns the created task with its `id`. If `--message` is provided without `--stream` or `--wait`, the response is fire-and-forget — use `tasks messages` to check later.
+
+**Project resolution — agent behavior when user does not specify a project:**
+
+1. **Omit `--project`.** The CLI automatically uses the project marked `isDefault: true`. If this succeeds, you're done.
+2. **If the CLI errors with "no default project found"**, run `projects list` yourself, review the project names/descriptions, and pick the most appropriate one based on the user's prompt context (e.g., if the user asks about PCR protocols and there's a "Protocol Lab" project, use that). Pass the chosen project ID with `--project`.
+3. **If no project clearly matches the user's intent**, show the user the project list and ask which one to use. Do not guess blindly.
 
 ### Send Message
 
@@ -165,17 +181,16 @@ MCP tools accept the same parameters as CLI flags (camelCase). `elnora_tasks_sen
 
 ## Agent Recipes
 
-**Create task and stream the response:**
+**Create task and stream the response (uses default project):**
 
 ```bash
-PROJECT=$($CLI --compact --fields "id" projects list | jq -r '.items[0].id')
-$CLI --compact tasks create --project "$PROJECT" --title "PCR BRCA1" --message "Generate PCR protocol for BRCA1 exon 11" --stream
+$CLI --compact tasks create --title "PCR BRCA1" --message "Generate PCR protocol for BRCA1 exon 11" --stream
 ```
 
 **Two-step (capture task ID, then stream follow-ups):**
 
 ```bash
-TASK=$($CLI --compact tasks create --project "$PROJECT" --title "PCR BRCA1" | jq -r '.id')
+TASK=$($CLI --compact tasks create --title "PCR BRCA1" | jq -r '.id')
 $CLI --compact tasks send "$TASK" --message "Generate PCR protocol for BRCA1 exon 11" --stream
 $CLI --compact tasks send "$TASK" --message "Add gel electrophoresis step" --stream
 ```

--- a/src/commands/tasks/create.ts
+++ b/src/commands/tasks/create.ts
@@ -7,11 +7,7 @@ import { collectStreamResponse, streamTask } from "../../lib/stream.js";
 import { StreamRenderer } from "../../lib/stream-renderer.js";
 
 const inputSchema = z.object({
-	project: z
-		.string()
-		.uuid()
-		.optional()
-		.describe("Project ID (uses default project if omitted)"),
+	project: z.string().uuid().optional().describe("Project ID (uses default project if omitted)"),
 	title: z.string().optional().describe("Task title"),
 	message: z.string().optional().describe("Initial message"),
 	wait: z.boolean().default(false).describe("Wait for agent response (polling)"),

--- a/src/commands/tasks/create.ts
+++ b/src/commands/tasks/create.ts
@@ -7,7 +7,11 @@ import { collectStreamResponse, streamTask } from "../../lib/stream.js";
 import { StreamRenderer } from "../../lib/stream-renderer.js";
 
 const inputSchema = z.object({
-	project: z.string().uuid().describe("Project ID"),
+	project: z
+		.string()
+		.uuid()
+		.optional()
+		.describe("Project ID (uses default project if omitted)"),
 	title: z.string().optional().describe("Task title"),
 	message: z.string().optional().describe("Initial message"),
 	wait: z.boolean().default(false).describe("Wait for agent response (polling)"),
@@ -24,8 +28,22 @@ export const tasksCreate: ElnoraCommand<Input> = {
 	outputSchema: z.any(),
 
 	async execute(input, ctx) {
+		let projectId = input.project;
+		if (!projectId) {
+			const projects = (await ctx.client.get("projects", {
+				queryParams: { pageSize: 100 },
+			})) as { items: { id: string; isDefault: boolean }[] };
+			const defaultProject = projects.items.find((p) => p.isDefault);
+			if (!defaultProject) {
+				throw new Error(
+					"No --project specified and no default project found. Set a default project or pass --project.",
+				);
+			}
+			projectId = defaultProject.id;
+		}
+
 		const result = (await ctx.client.post("tasks", {
-			projectId: input.project,
+			projectId,
 			title: input.title,
 			initialMessage: input.message,
 		})) as { id: string; [key: string]: unknown };


### PR DESCRIPTION
## Summary
- Make `--project` optional on `tasks create` — CLI auto-selects the project marked `isDefault: true`
- Add agent fallback instructions: list projects → pick best match → ask user if unclear
- Add real-time streaming event relay guidance (think, tool_start/end, progress events)

## Test plan
- [x] All 46 existing task tests pass
- [ ] Verify `tasks create` without `--project` uses default project (requires account with default project)
- [ ] Verify clear error when no default project exists
- [ ] Verify `--project <UUID>` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)