### PR TITLE
fix: make update check-only by default, add --install flag

### DIFF
--- a/__tests__/lib/install-method.test.ts
+++ b/__tests__/lib/install-method.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+import { getUpdateInstruction } from "../../src/lib/install-method.js";
+
+describe("getUpdateInstruction", () => {
+	test("returns npm command for npm installs", () => {
+		expect(getUpdateInstruction("npm")).toBe("npm update -g @elnora-ai/cli");
+	});
+
+	test("returns brew command for homebrew installs", () => {
+		expect(getUpdateInstruction("homebrew")).toBe("brew upgrade elnora");
+	});
+
+	test("returns elnora update --install for binary installs", () => {
+		expect(getUpdateInstruction("binary")).toBe("elnora update --install");
+	});
+});

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -21,8 +21,8 @@ const msg = `
   │   To get started, run:                                       │
   │     elnora auth login                                        │
   │                                                              │
-  │   Using Claude Code? Run:                                    │
-  │     elnora setup-claude                                      │
+  │   Set up your AI coding tools:                                │
+  │     elnora setup                                             │
   │                                                              │
   │   Documentation:                                             │
   │     https://github.com/Elnora-AI/elnora-cli                  │

--- a/skills/elnora-platform/SKILL.md
+++ b/skills/elnora-platform/SKILL.md
@@ -35,6 +35,10 @@ $CLI projects list --compact            # also works for most commands
 | `--profile <name>` | Named profile (default: `default`). Set with `auth login --api-key <KEY> --profile <name>` |
 | `--json` | Force JSON output |
 
+## Updates
+
+On first use in a session, run `elnora update` to check for updates. If an update is available, inform the user and offer to run `elnora update --install`.
+
 ## Auth
 
 Requires `ELNORA_API_KEY` environment variable (prefix: `elnora_live_`), `ELNORA_MCP_API_KEY`, or a saved profile in `~/.elnora/profiles.toml`.

--- a/skills/elnora-platform/SKILL.md
+++ b/skills/elnora-platform/SKILL.md
@@ -173,6 +173,6 @@ elnora projects     Manage projects
 elnora search       Search tasks, files, and file content
 elnora setup        Configure AI coding tools (Claude Code, Cursor, VS Code, Codex)
 elnora tasks        Manage tasks
-elnora update       Self-update the CLI to the latest version
+elnora update       Check for updates (use --install to apply)
 elnora whoami       Show current profile and org
 ```

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -8,6 +8,7 @@ import { pipeline } from "node:stream/promises";
 import type { Command } from "commander";
 import pc from "picocolors";
 import { VERSION } from "../lib/config.js";
+import { detectInstallMethod, getUpdateInstruction } from "../lib/install-method.js";
 import { isColorEnabled } from "../lib/tty.js";
 import { isNewerVersion } from "../lib/update-check.js";
 
@@ -28,10 +29,11 @@ function getPlatformTarget(): { target: string; ext: string } | null {
 	}
 }
 
-function getManualHint(): string {
-	return process.platform === "win32"
-		? "  irm https://cli.elnora.ai/install.ps1 | iex"
-		: "  curl -fsSL https://cli.elnora.ai/install.sh | bash";
+async function fetchLatestVersion(): Promise<string> {
+	const res = await fetch(NPM_REGISTRY_URL, { signal: AbortSignal.timeout(5000) });
+	if (!res.ok) throw new Error(`Registry returned HTTP ${res.status}`);
+	const data = (await res.json()) as { version?: string };
+	return data.version ?? "unknown";
 }
 
 async function downloadToFile(url: string, dest: string): Promise<void> {
@@ -41,31 +43,109 @@ async function downloadToFile(url: string, dest: string): Promise<void> {
 	await pipeline(nodeStream, createWriteStream(dest));
 }
 
+async function installBinaryUpdate(latest: string): Promise<void> {
+	const color = isColorEnabled();
+	const platformInfo = getPlatformTarget();
+	if (!platformInfo) {
+		console.error(`Unsupported platform: ${process.platform}.`);
+		console.error("Try: npm update -g @elnora-ai/cli");
+		process.exitCode = 1;
+		return;
+	}
+
+	const { target, ext } = platformInfo;
+	const binaryUrl = `https://github.com/${GITHUB_REPO}/releases/download/v${latest}/${target}.${ext}`;
+	const checksumUrl = `https://github.com/${GITHUB_REPO}/releases/download/v${latest}/${target}.sha256`;
+
+	const tmp = join(tmpdir(), `elnora-update-${Date.now()}`);
+	mkdirSync(tmp, { recursive: true });
+	const archivePath = join(tmp, `${target}.${ext}`);
+
+	try {
+		console.error("Downloading...");
+		await downloadToFile(binaryUrl, archivePath);
+
+		// Verify checksum
+		let checksumVerified = false;
+		try {
+			const checksumRes = await fetch(checksumUrl, { signal: AbortSignal.timeout(15_000) });
+			if (checksumRes.ok) {
+				const checksumText = await checksumRes.text();
+				const expected = checksumText.split(/\s/)[0].trim();
+				if (expected.length === 64) {
+					const actual = createHash("sha256").update(readFileSync(archivePath)).digest("hex");
+					if (actual.toLowerCase() !== expected.toLowerCase()) {
+						console.error("Checksum verification failed. The download may be corrupted.");
+						process.exitCode = 1;
+						return;
+					}
+					checksumVerified = true;
+				}
+			}
+		} catch {
+			/* continue without verification */
+		}
+		if (!checksumVerified) {
+			console.error("Warning: Could not verify download checksum. Proceeding anyway.");
+		}
+
+		// Extract and install
+		if (process.platform === "win32") {
+			const extractDir = join(tmp, "extracted");
+			execFileSync("powershell", [
+				"-NoProfile",
+				"-Command",
+				`Expand-Archive -Path '${archivePath}' -DestinationPath '${extractDir}' -Force`,
+			]);
+			const installDir = join(process.env.USERPROFILE ?? process.env.HOME ?? "", ".elnora", "bin");
+			mkdirSync(installDir, { recursive: true });
+			copyFileSync(join(extractDir, target), join(installDir, "elnora.exe"));
+		} else {
+			execFileSync("tar", ["-xzf", archivePath, "-C", tmp]);
+			const installDir = process.env.ELNORA_INSTALL_DIR ?? join(process.env.HOME ?? "", ".local", "bin");
+			mkdirSync(installDir, { recursive: true });
+			const dest = join(installDir, "elnora");
+			copyFileSync(join(tmp, target), dest);
+			chmodSync(dest, 0o755);
+		}
+
+		const done = color ? `${pc.green("✓")} Updated to v${latest}` : `✓ Updated to v${latest}`;
+		console.error(done);
+	} finally {
+		try {
+			rmSync(tmp, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	}
+}
+
 export function addUpdateCommand(program: Command): void {
 	program
 		.command("update")
-		.description("Update Elnora CLI to the latest version")
-		.action(async () => {
+		.description("Check for updates (use --install to apply)")
+		.option("--install", "Download and install the update")
+		.action(async (opts: { install?: boolean }) => {
 			const color = isColorEnabled();
-			const hint = getManualHint();
+			const method = detectInstallMethod();
 
 			// Check latest version
 			let latest: string;
 			try {
-				const res = await fetch(NPM_REGISTRY_URL, { signal: AbortSignal.timeout(5000) });
-				if (!res.ok) {
-					console.error("Failed to check for updates. Try manually:");
-					console.error(hint);
-					process.exit(1);
-				}
-				const data = (await res.json()) as { version?: string };
-				latest = data.version ?? "unknown";
+				latest = await fetchLatestVersion();
 			} catch {
-				console.error("Failed to reach registry. Try manually:");
-				console.error(hint);
-				process.exit(1);
+				console.error("Failed to check for updates.");
+				process.exitCode = 1;
+				return;
 			}
 
+			if (latest === "unknown") {
+				console.error("Could not determine latest version.");
+				process.exitCode = 1;
+				return;
+			}
+
+			// Already up to date
 			if (latest === VERSION || !isNewerVersion(latest, VERSION)) {
 				const msg = color
 					? `${pc.green("✓")} Already on the latest version (v${VERSION})`
@@ -74,86 +154,48 @@ export function addUpdateCommand(program: Command): void {
 				return;
 			}
 
+			// Update available
+			const instruction = getUpdateInstruction(method);
+
+			if (!opts.install) {
+				// Check-only mode (default)
+				const msg = color
+					? `${pc.yellow("Update available:")} v${VERSION} → v${latest}`
+					: `Update available: v${VERSION} → v${latest}`;
+				console.error(msg);
+				console.error(`Run: ${instruction}`);
+				return;
+			}
+
+			// --install mode
 			const msg = color
 				? `Updating Elnora CLI ${pc.dim(`v${VERSION}`)} → ${pc.green(`v${latest}`)}...`
 				: `Updating Elnora CLI v${VERSION} → v${latest}...`;
 			console.error(msg);
 
-			const platformInfo = getPlatformTarget();
-			if (!platformInfo) {
-				console.error(`\nUnsupported platform: ${process.platform}. Try manually:`);
-				console.error("  npm update -g @elnora-ai/cli");
-				process.exit(1);
+			if (method === "npm") {
+				console.error("Installed via npm. Run:");
+				console.error(`  npm update -g @elnora-ai/cli`);
+				return;
 			}
 
-			const { target, ext } = platformInfo;
-			const binaryUrl = `https://github.com/${GITHUB_REPO}/releases/download/v${latest}/${target}.${ext}`;
-			const checksumUrl = `https://github.com/${GITHUB_REPO}/releases/download/v${latest}/${target}.sha256`;
+			if (method === "homebrew") {
+				console.error("Installed via Homebrew. Run:");
+				console.error(`  brew upgrade elnora`);
+				return;
+			}
 
-			const tmp = join(tmpdir(), `elnora-update-${Date.now()}`);
-			mkdirSync(tmp, { recursive: true });
-			const archivePath = join(tmp, `${target}.${ext}`);
-
+			// Binary self-replace
 			try {
-				await downloadToFile(binaryUrl, archivePath);
-
-				// Verify checksum
-				let checksumVerified = false;
-				try {
-					const checksumRes = await fetch(checksumUrl, { signal: AbortSignal.timeout(15_000) });
-					if (checksumRes.ok) {
-						const checksumText = await checksumRes.text();
-						const expected = checksumText.split(/\s/)[0].trim();
-						if (expected.length === 64) {
-							const actual = createHash("sha256").update(readFileSync(archivePath)).digest("hex");
-							if (actual.toLowerCase() !== expected.toLowerCase()) {
-								console.error("\nChecksum verification failed. The download may be corrupted.");
-								console.error("Try again, or install manually:");
-								console.error(hint);
-								process.exit(1);
-							}
-							checksumVerified = true;
-						}
-					}
-				} catch {
-					/* continue without verification */
-				}
-				if (!checksumVerified) {
-					console.error("Warning: Could not verify download checksum. Proceeding anyway.");
-				}
-
-				// Extract and install
-				if (process.platform === "win32") {
-					const extractDir = join(tmp, "extracted");
-					execFileSync("powershell", [
-						"-NoProfile",
-						"-Command",
-						`Expand-Archive -Path '${archivePath}' -DestinationPath '${extractDir}' -Force`,
-					]);
-					const installDir = join(process.env.USERPROFILE ?? process.env.HOME ?? "", ".elnora", "bin");
-					mkdirSync(installDir, { recursive: true });
-					copyFileSync(join(extractDir, target), join(installDir, "elnora.exe"));
-				} else {
-					execFileSync("tar", ["-xzf", archivePath, "-C", tmp]);
-					const installDir = process.env.ELNORA_INSTALL_DIR ?? join(process.env.HOME ?? "", ".local", "bin");
-					mkdirSync(installDir, { recursive: true });
-					const dest = join(installDir, "elnora");
-					copyFileSync(join(tmp, target), dest);
-					chmodSync(dest, 0o755);
-				}
-
-				const done = color ? `${pc.green("✓")} Updated to v${latest}` : `✓ Updated to v${latest}`;
-				console.error(done);
+				await installBinaryUpdate(latest);
 			} catch {
-				console.error("\nUpdate failed. Try manually:");
-				console.error(hint);
-				process.exit(1);
-			} finally {
-				try {
-					rmSync(tmp, { recursive: true, force: true });
-				} catch {
-					/* ignore */
-				}
+				console.error("Update failed. Try manually:");
+				console.error(
+					process.platform === "win32"
+						? "  irm https://cli.elnora.ai/install.ps1 | iex"
+						: "  curl -fsSL https://cli.elnora.ai/install.sh | bash",
+				);
+				process.exitCode = 1;
 			}
 		});
 }

--- a/src/lib/install-method.ts
+++ b/src/lib/install-method.ts
@@ -1,0 +1,30 @@
+/**
+ * Detect how the CLI was installed — determines update instructions.
+ */
+
+export type InstallMethod = "npm" | "homebrew" | "binary";
+
+export function detectInstallMethod(): InstallMethod {
+	const execPath = process.argv[1] ?? "";
+
+	if (execPath.includes("node_modules")) {
+		return "npm";
+	}
+
+	if (execPath.includes("/Cellar/") || execPath.includes("/homebrew/")) {
+		return "homebrew";
+	}
+
+	return "binary";
+}
+
+export function getUpdateInstruction(method: InstallMethod): string {
+	switch (method) {
+		case "npm":
+			return "npm update -g @elnora-ai/cli";
+		case "homebrew":
+			return "brew upgrade elnora";
+		case "binary":
+			return "elnora update --install";
+	}
+}

--- a/src/lib/update-check.ts
+++ b/src/lib/update-check.ts
@@ -1,8 +1,9 @@
 /**
  * Background update check — non-blocking, 24h cache.
  *
- * Port of: elnora-cli/src/elnora/lib/update_check.py (69 lines)
- * Adapted for npm registry instead of PyPI.
+ * The cache refresh always runs (even in non-TTY) so that the next
+ * interactive session has fresh data. The notification is only shown
+ * in TTY contexts.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -24,13 +25,9 @@ interface CacheEntry {
 	latest: string;
 }
 
-function shouldSkip(): boolean {
-	// Skip in CI
+function shouldSkipEntirely(): boolean {
 	if (process.env.CI || process.env.GITHUB_ACTIONS) return true;
-	// Skip if opted out
 	if (process.env.ELNORA_NO_UPDATE_CHECK) return true;
-	// Skip in non-TTY (piped output)
-	if (!process.stderr.isTTY) return true;
 	return false;
 }
 
@@ -54,10 +51,13 @@ function writeCache(entry: CacheEntry): void {
 }
 
 function showUpdateNotice(latest: string): void {
+	// Only show in TTY
+	if (!process.stderr.isTTY) return;
+
 	const color = isColorEnabled();
 	const msg = color
-		? `\n${pc.yellow(`Update available: v${VERSION} → v${latest}`)}\nRun: curl -fsSL https://cli.elnora.ai/install.sh | bash\n`
-		: `\nUpdate available: v${VERSION} → v${latest}\nRun: curl -fsSL https://cli.elnora.ai/install.sh | bash\n`;
+		? `\n${pc.yellow(`Update available: v${VERSION} → v${latest}`)}\nRun: elnora update\n`
+		: `\nUpdate available: v${VERSION} → v${latest}\nRun: elnora update\n`;
 	process.stderr.write(msg);
 }
 
@@ -76,10 +76,10 @@ export function isNewerVersion(a: string, b: string): boolean {
 
 /**
  * Register update check to run at process exit.
- * Non-blocking — uses a fire-and-forget fetch.
+ * Cache refresh runs even in non-TTY; notification only in TTY.
  */
 export function registerUpdateCheck(): void {
-	if (shouldSkip()) return;
+	if (shouldSkipEntirely()) return;
 
 	// Check cache first
 	const cached = readCache();
@@ -88,7 +88,6 @@ export function registerUpdateCheck(): void {
 		if (elapsed < CHECK_INTERVAL_MS) {
 			// Cache is fresh — show notice if update available
 			if (cached.latest && cached.latest !== VERSION && cached.latest !== "unknown") {
-				// Compare versions simply — assumes semver
 				if (isNewerVersion(cached.latest, VERSION)) {
 					showUpdateNotice(cached.latest);
 				}
@@ -98,8 +97,7 @@ export function registerUpdateCheck(): void {
 	}
 
 	// Cache is stale or missing — fetch in background
-	// Use setTimeout(0) to ensure it doesn't block the main command
-	setTimeout(async () => {
+	const fetchPromise = (async () => {
 		try {
 			const response = await fetch(NPM_REGISTRY_URL, {
 				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
@@ -108,7 +106,6 @@ export function registerUpdateCheck(): void {
 			const data = (await response.json()) as { version?: string };
 			const latest = data.version ?? "unknown";
 
-			// Validate version is a safe semver string before writing to cache file
 			if (latest !== "unknown" && !SEMVER_RE.test(latest)) return;
 
 			writeCache({ checkedAt: new Date().toISOString(), latest });
@@ -117,7 +114,14 @@ export function registerUpdateCheck(): void {
 				showUpdateNotice(latest);
 			}
 		} catch {
-			// Silently ignore — never block or error on update check
+			// Silently ignore
 		}
-	}, 0);
+	})();
+
+	// Keep the process alive until the fetch completes (max 3s timeout anyway)
+	// Use unref() so it doesn't prevent exit if the main command is done,
+	// but beforeExit will let it finish if there's nothing else pending.
+	process.once("beforeExit", () => {
+		fetchPromise.catch(() => {});
+	});
 }

--- a/src/lib/update-check.ts
+++ b/src/lib/update-check.ts
@@ -96,8 +96,12 @@ export function registerUpdateCheck(): void {
 		}
 	}
 
-	// Cache is stale or missing — fetch in background
-	const fetchPromise = (async () => {
+	// Cache is stale or missing — fetch in background.
+	// Keep the process alive with a ref'd timer until the fetch completes
+	// (bounded by FETCH_TIMEOUT_MS = 3s so it never hangs).
+	const keepAlive = setInterval(() => {}, 60_000);
+
+	(async () => {
 		try {
 			const response = await fetch(NPM_REGISTRY_URL, {
 				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
@@ -115,13 +119,8 @@ export function registerUpdateCheck(): void {
 			}
 		} catch {
 			// Silently ignore
+		} finally {
+			clearInterval(keepAlive);
 		}
 	})();
-
-	// Keep the process alive until the fetch completes (max 3s timeout anyway)
-	// Use unref() so it doesn't prevent exit if the main command is done,
-	// but beforeExit will let it finish if there's nothing else pending.
-	process.once("beforeExit", () => {
-		fetchPromise.catch(() => {});
-	});
 }


### PR DESCRIPTION
## Summary

- `elnora update` is now **check-only by default** — reports whether an update is available with install-method-aware instructions
- `elnora update --install` performs the actual update (binary self-replace for binary installs, prints the right package manager command for npm/homebrew)
- Detects install method at runtime (npm/homebrew/binary) to give correct update instructions
- Background cache refresh now works in non-TTY (Claude Code) — notification is still TTY-only
- Update notice says `elnora update` instead of hardcoded `curl ... install.sh` command
- Skills tell Claude Code to run `elnora update` on first use, inform user if update available
- Fix postinstall.mjs: `setup-claude` → `setup`

Fixes ELN-622

## Test plan

- [x] 554 tests pass (3 new)
- [x] Type-check clean
- [x] `elnora update` shows "Already on latest (v1.3.0)" — check-only, no action
- [x] `elnora update --help` shows --install flag
- [x] Background cache refreshed (was stuck at 1.1.1 from April 8, now shows 1.3.0)
- [x] Skills updated with update check guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)