### PR TITLE
fix: use build-npm.mjs to inject version into npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "esbuild src/cli.ts --bundle --format=esm --platform=node --target=node20 --outfile=dist/cli.js --packages=external",
+    "build": "node scripts/build-npm.mjs",
     "build:binary": "node scripts/build.mjs --pkg",
     "dev": "tsx src/cli.ts",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

Fixes `elnora --version` showing `0.0.0-dev` when installed via npm. The build script was not injecting the version from package.json into the output bundle.

## Test plan

- [x] `pnpm build` succeeds
- [x] `elnora --version` shows correct version (was `0.0.0-dev`)
- [x] All 554 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)