### PR TITLE
fix: use npm install @latest for update instruction

### DIFF
--- a/__tests__/lib/install-method.test.ts
+++ b/__tests__/lib/install-method.test.ts
@@ -3,7 +3,7 @@ import { getUpdateInstruction } from "../../src/lib/install-method.js";
 
 describe("getUpdateInstruction", () => {
 	test("returns npm command for npm installs", () => {
-		expect(getUpdateInstruction("npm")).toBe("npm update -g @elnora-ai/cli");
+		expect(getUpdateInstruction("npm")).toBe("npm install -g @elnora-ai/cli@latest");
 	});
 
 	test("returns brew command for homebrew installs", () => {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -48,7 +48,7 @@ async function installBinaryUpdate(latest: string): Promise<void> {
 	const platformInfo = getPlatformTarget();
 	if (!platformInfo) {
 		console.error(`Unsupported platform: ${process.platform}.`);
-		console.error("Try: npm update -g @elnora-ai/cli");
+		console.error("Try: npm install -g @elnora-ai/cli@latest");
 		process.exitCode = 1;
 		return;
 	}
@@ -175,7 +175,7 @@ export function addUpdateCommand(program: Command): void {
 
 			if (method === "npm") {
 				console.error("Installed via npm. Run:");
-				console.error(`  npm update -g @elnora-ai/cli`);
+				console.error(`  npm install -g @elnora-ai/cli@latest`);
 				return;
 			}
 

--- a/src/lib/install-method.ts
+++ b/src/lib/install-method.ts
@@ -21,7 +21,7 @@ export function detectInstallMethod(): InstallMethod {
 export function getUpdateInstruction(method: InstallMethod): string {
 	switch (method) {
 		case "npm":
-			return "npm update -g @elnora-ai/cli";
+			return "npm install -g @elnora-ai/cli@latest";
 		case "homebrew":
 			return "brew upgrade elnora";
 		case "binary":


### PR DESCRIPTION
## Summary

`elnora update` was telling npm users to run `npm update -g @elnora-ai/cli`, which doesn't reliably pick up new versions. Changed to `npm install -g @elnora-ai/cli@latest` which always works.

## Test plan

- [x] All 554 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)