### PR TITLE
fix: simplify update guidance in platform skill

### DIFF
--- a/skills/elnora-platform/SKILL.md
+++ b/skills/elnora-platform/SKILL.md
@@ -37,7 +37,7 @@ $CLI projects list --compact            # also works for most commands
 
 ## Updates
 
-On first use in a session, run `elnora update` to check for updates. If an update is available, inform the user and offer to run `elnora update --install`.
+On first use in a session, run `elnora update` to check for updates. If an update is available, inform the user and follow the printed instructions to update.
 
 ## Auth
 


### PR DESCRIPTION
## Summary

Simplify the update guidance in the platform skill. Instead of telling Claude to offer `elnora update --install`, just say "follow the printed instructions" — this way the correct command is used automatically for each install method (npm, homebrew, or binary).

## Test plan

- [x] Skill reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)