### PR TITLE
fix: resolve critical usability issues blocking first-time install (ELN-627, ELN-628, ELN-629, ELN-630, ELN-631)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Normalize line endings to LF in the repo, let git handle checkout per-OS
+* text=auto eol=lf
+
+# Ensure these are always LF regardless of OS
+*.ts text eol=lf
+*.js text eol=lf
+*.mjs text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.sh text eol=lf
+*.toml text eol=lf
+
+# Keep Windows scripts as CRLF
+*.ps1 text eol=crlf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary files
+*.png binary
+*.ico binary
+*.exe binary

--- a/README.md
+++ b/README.md
@@ -39,6 +39,50 @@ npm install -g @elnora-ai/cli
 brew install elnora-ai/cli/elnora
 ```
 
+## Skills & Setup
+
+After installing the CLI, configure your AI coding tools:
+
+```bash
+elnora setup
+```
+
+This auto-detects which tools you have installed and configures them:
+
+- **Claude Code** — registers the `elnora-plugins` marketplace and enables 9 skills (`elnora-tasks`, `elnora-projects`, `elnora-files`, etc.) so you can use natural language.
+- **Cursor / VS Code / Codex** — writes an MCP server config pointing at `https://mcp.elnora.ai/mcp` with your API key.
+
+Target a specific tool: `elnora setup claude` · `elnora setup cursor` · `elnora setup vscode` · `elnora setup codex`.
+
+### What You Get in Claude Code
+
+Once configured, restart Claude Code and try any natural-language request:
+
+> "Use Elnora to generate a PCR protocol for BRCA1 exon 11"
+> "Use Elnora to list my projects"
+> "Use Elnora to optimize the protocol in task abc-123"
+
+Claude will invoke the `elnora` CLI under the hood using the bundled skills. No need to memorize command syntax.
+
+### Where Everything Lives
+
+| What | Where |
+|------|-------|
+| CLI binary (macOS/Linux) | `~/.local/bin/elnora` |
+| CLI binary (Windows) | `%USERPROFILE%\.elnora\bin\elnora.exe` |
+| Auth / profiles | `~/.elnora/profiles.toml` (mode 0600) |
+| Claude Code skills | `~/.claude/plugins/marketplaces/elnora-plugins/elnora/skills/` (auto-updated) |
+| Claude Code settings | `~/.claude/settings.json` — look for `elnora@elnora-plugins: true` |
+
+### Manual Plugin Setup
+
+If `elnora setup claude` doesn't work for some reason, you can install the plugin manually:
+
+1. In Claude Code, run `/plugin`
+2. Choose "Add marketplace"
+3. Enter: `Elnora-AI/elnora-plugins`
+4. Run `/plugin` again → Plugins → Enable `elnora`
+
 ## Quick Start
 
 ```bash

--- a/__tests__/lib/prompt.test.ts
+++ b/__tests__/lib/prompt.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 describe("promptSecret", () => {
 	test("module exports promptSecret function", async () => {
@@ -11,7 +11,7 @@ describe("promptSecret", () => {
 
 		// Save originals
 		const origStdin = process.stdin;
-		const origIsTTY = process.stdin.isTTY;
+		const _origIsTTY = process.stdin.isTTY;
 
 		// Create a readable stream that emits a line
 		const mockStdin = new Readable({

--- a/homebrew/elnora.rb.tpl
+++ b/homebrew/elnora.rb.tpl
@@ -36,6 +36,17 @@ class Elnora < Formula
     end
   end
 
+  def caveats
+    <<~EOS
+      To get started:
+
+        elnora auth login
+        elnora setup          # Configure Claude Code, Cursor, etc.
+
+      You'll need an API key from https://platform.elnora.ai
+    EOS
+  end
+
   test do
     assert_match version.to_s, shell_output("#{bin}/elnora --version")
   end

--- a/install.ps1
+++ b/install.ps1
@@ -128,18 +128,25 @@ try {
     exit 1
 }
 
-# Add to PATH
+# Add to PATH — persist AND update current session
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
 if ($userPath -notlike "*$InstallDir*") {
     try {
         [Environment]::SetEnvironmentVariable("Path", "$InstallDir;$userPath", "User")
-        Write-Host ""
-        Write-Host "Added $InstallDir to user PATH. Restart your terminal to use 'elnora'."
+        $env:PATH = "$InstallDir;$env:PATH"
+        Write-Host "  Added $InstallDir to PATH"
     } catch {
-        Write-Host ""
-        Write-Host "Warning: Could not add $InstallDir to PATH automatically."
-        Write-Host "  Add it manually: Settings > System > About > Advanced > Environment Variables > Path"
+        # Persist failed, but still update current session
+        $env:PATH = "$InstallDir;$env:PATH"
+        Write-Host "  Added $InstallDir to PATH (current session only)"
+        Write-Host "  To persist, add it manually via Settings > System > Environment Variables"
     }
+} else {
+    # Already in persisted PATH, ensure current session has it too
+    if ($env:PATH -notlike "*$InstallDir*") {
+        $env:PATH = "$InstallDir;$env:PATH"
+    }
+    Write-Host "  PATH already includes $InstallDir"
 }
 
 # Extract skills if bundled in the archive
@@ -153,17 +160,45 @@ if (Test-Path "$TmpDir\skills") {
 Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
 
 Write-Host ""
-Write-Host "Elnora CLI $Version installed to $InstallDir\elnora.exe"
-Write-Host ""
+Write-Host "  Elnora CLI $Version installed to $InstallDir\elnora.exe"
 
-# Run interactive login
+# ---------------------------------------------------------------------------
+# Auth login — interactive only
+# ---------------------------------------------------------------------------
+
+$AuthOk = $false
 if ([Environment]::UserInteractive) {
-    & "$InstallDir\elnora.exe" auth login
     Write-Host ""
-    Write-Host "Using Claude Code or another AI tool? Run:"
-    Write-Host "  elnora setup-claude"
+    try {
+        & "$InstallDir\elnora.exe" auth login
+        $AuthOk = $true
+    } catch {
+        # Auth failed or was cancelled — continue to setup
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Auto-setup — detect and configure AI coding tools
+# ---------------------------------------------------------------------------
+
+if ([Environment]::UserInteractive) {
+    try {
+        & "$InstallDir\elnora.exe" setup
+    } catch {
+        # Setup failed — non-fatal
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Success banner
+# ---------------------------------------------------------------------------
+
+Write-Host ""
+if ($AuthOk) {
+    Write-Host "  Done! To get started, run: elnora --help" -ForegroundColor Green
 } else {
-    Write-Host "To get started:"
-    Write-Host "  elnora auth login"
-    Write-Host "  elnora setup-claude    # If using Claude Code"
+    Write-Host "  To get started:"
+    Write-Host "    elnora auth login"
+    Write-Host "    elnora setup          # Configure AI coding tools"
+    Write-Host "    elnora --help"
 }

--- a/install.sh
+++ b/install.sh
@@ -104,50 +104,92 @@ if [ -d "skills" ]; then
 fi
 
 echo ""
-echo "Elnora CLI ${VERSION} installed to $INSTALL_DIR/elnora"
+echo "  Elnora CLI ${VERSION} installed to $INSTALL_DIR/elnora"
 
-# PATH guidance
-case "${SHELL:-unknown}" in
-  */zsh)
-    RC="$HOME/.zshrc"
-    if ! echo "$PATH" | grep -q "$INSTALL_DIR"; then
-      echo ""
-      echo "Add to your PATH by running:"
-      echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> $RC && source $RC"
-    fi
-    ;;
-  */bash)
-    RC="$HOME/.bashrc"
-    if ! echo "$PATH" | grep -q "$INSTALL_DIR"; then
-      echo ""
-      echo "Add to your PATH by running:"
-      echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> $RC && source $RC"
-    fi
-    ;;
-  */fish)
-    if ! echo "$PATH" | grep -q "$INSTALL_DIR"; then
-      echo ""
-      echo "Add to your PATH by running:"
-      echo "  fish_add_path $INSTALL_DIR"
-    fi
-    ;;
-  *)
-    if ! echo "$PATH" | grep -q "$INSTALL_DIR"; then
-      echo ""
-      echo "Add $INSTALL_DIR to your shell's PATH to use 'elnora' from anywhere."
-    fi
-    ;;
-esac
+# ---------------------------------------------------------------------------
+# Auto-PATH — add INSTALL_DIR to shell rc and current session
+# ---------------------------------------------------------------------------
 
-# Run interactive login — reads from /dev/tty since stdin is piped from curl
-echo ""
-if [ -t 1 ]; then
-  "$INSTALL_DIR/elnora" auth login </dev/tty
-  echo ""
-  echo "Using Claude Code or another AI tool? Run:"
-  echo "  elnora setup-claude"
+if echo "$PATH" | grep -q "$INSTALL_DIR"; then
+  echo "  PATH already includes $INSTALL_DIR"
 else
-  echo "To get started:"
-  echo "  elnora auth login"
-  echo "  elnora setup-claude    # If using Claude Code"
+  export PATH="$INSTALL_DIR:$PATH"
+
+  if [ -t 1 ]; then
+    # Interactive: append to shell rc file
+    case "${SHELL:-unknown}" in
+      */zsh)
+        RC="$HOME/.zshrc"
+        [ -f "$HOME/.zprofile" ] && [ ! -f "$RC" ] && RC="$HOME/.zprofile"
+        ;;
+      */bash)
+        # macOS uses .bash_profile for login shells; Linux uses .bashrc
+        if [ "$(uname -s)" = "Darwin" ]; then
+          RC="$HOME/.bash_profile"
+        else
+          RC="$HOME/.bashrc"
+        fi
+        ;;
+      */fish)
+        RC="$HOME/.config/fish/config.fish"
+        ;;
+      *)
+        RC=""
+        ;;
+    esac
+
+    if [ -n "$RC" ]; then
+      if [ "${SHELL:-}" = "*/fish" ] 2>/dev/null; then
+        echo "set -gx PATH $INSTALL_DIR \$PATH" >> "$RC"
+      else
+        echo "export PATH=\"$INSTALL_DIR:\$PATH\"" >> "$RC"
+      fi
+      echo "  Added $INSTALL_DIR to PATH (in $RC)"
+    else
+      echo "  Added $INSTALL_DIR to PATH (current session only)"
+      echo "  To persist, add this to your shell config:"
+      echo "    export PATH=\"$INSTALL_DIR:\$PATH\""
+    fi
+  else
+    # Non-interactive: just print the export command
+    echo "  Add to PATH: export PATH=\"$INSTALL_DIR:\$PATH\""
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Auth login — interactive only (stdin is piped from curl, use /dev/tty)
+# ---------------------------------------------------------------------------
+
+AUTH_OK=""
+if [ -t 1 ]; then
+  echo ""
+  if "$INSTALL_DIR/elnora" auth login </dev/tty 2>/dev/null; then
+    AUTH_OK=1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Auto-setup — detect and configure AI coding tools
+# ---------------------------------------------------------------------------
+
+SETUP_OUTPUT=""
+if [ -t 1 ]; then
+  SETUP_OUTPUT=$("$INSTALL_DIR/elnora" setup 2>&1) || true
+  if [ -n "$SETUP_OUTPUT" ]; then
+    echo "$SETUP_OUTPUT" >&2
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Success banner
+# ---------------------------------------------------------------------------
+
+echo ""
+if [ -n "$AUTH_OK" ]; then
+  echo "  Done! To get started, run: elnora --help"
+else
+  echo "  To get started:"
+  echo "    elnora auth login"
+  echo "    elnora setup          # Configure AI coding tools"
+  echo "    elnora --help"
 fi

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "dist/cli.js",
   "files": [
     "dist/",
+    "scripts/postinstall.mjs",
     "README.md",
     "LICENSE"
   ],
@@ -19,6 +20,7 @@
     "access": "public"
   },
   "scripts": {
+    "postinstall": "node scripts/postinstall.mjs",
     "build": "node scripts/build-npm.mjs",
     "build:binary": "node scripts/build.mjs --pkg",
     "dev": "tsx src/cli.ts",

--- a/scripts/smoke-test-carmen.ps1
+++ b/scripts/smoke-test-carmen.ps1
@@ -1,0 +1,178 @@
+# ---------------------------------------------------------------------------
+# Carmen cold-start smoke test (Windows)
+#
+# Verifies the install -> auth -> setup -> skills flow works end-to-end.
+# Exits non-zero on any failure.
+#
+# Usage:
+#   # Full test (requires SMOKE_TEST_API_KEY env var):
+#   $env:SMOKE_TEST_API_KEY = "elnora_live_xxx"
+#   .\scripts\smoke-test-carmen.ps1
+#
+#   # Structure-only test (skips auth + API):
+#   .\scripts\smoke-test-carmen.ps1
+# ---------------------------------------------------------------------------
+
+$ErrorActionPreference = "Continue"
+$Pass = 0
+$Fail = 0
+
+function Test-Pass($msg) { Write-Host "  PASS: $msg"; $script:Pass++ }
+function Test-Fail($msg) { Write-Host "  FAIL: $msg"; $script:Fail++ }
+
+Write-Host "=== Carmen cold-start smoke test (Windows) ==="
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# 1. Binary exists and is executable
+# ---------------------------------------------------------------------------
+
+$elnora = Get-Command elnora -ErrorAction SilentlyContinue
+if ($elnora) {
+    Test-Pass "elnora is in PATH ($($elnora.Source))"
+} else {
+    $fallback = "$env:USERPROFILE\.elnora\bin\elnora.exe"
+    if (Test-Path $fallback) {
+        $env:PATH = "$env:USERPROFILE\.elnora\bin;$env:PATH"
+        Test-Pass "elnora found at $fallback (added to PATH)"
+    } else {
+        Test-Fail "elnora is NOT in PATH and not at $fallback"
+        Write-Host ""
+        Write-Host "Cannot continue without elnora binary."
+        exit 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 2. Version output
+# ---------------------------------------------------------------------------
+
+$version = & elnora --version 2>$null
+if ($version) {
+    Test-Pass "elnora --version -> $version"
+} else {
+    Test-Fail "elnora --version returned empty"
+}
+
+# ---------------------------------------------------------------------------
+# 3. setup-claude alias exists
+# ---------------------------------------------------------------------------
+
+$setupHelp = & elnora setup-claude --help 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Test-Pass "elnora setup-claude command exists"
+} else {
+    Test-Fail "elnora setup-claude command does not exist"
+}
+
+# ---------------------------------------------------------------------------
+# 4. setup claude writes correct marketplace entries
+# ---------------------------------------------------------------------------
+
+$claudeDir = "$env:USERPROFILE\.claude"
+if (Test-Path $claudeDir) {
+    & elnora setup claude 2>$null
+
+    $settings = "$claudeDir\settings.json"
+    if (Test-Path $settings) {
+        $content = Get-Content $settings -Raw
+        if ($content -match '"elnora@elnora-plugins"') {
+            Test-Pass "settings.json has elnora@elnora-plugins"
+        } else {
+            Test-Fail "settings.json missing elnora@elnora-plugins"
+        }
+
+        if ($content -match '"elnora@elnora-ai"') {
+            Test-Fail "settings.json still has broken elnora@elnora-ai"
+        } else {
+            Test-Pass "no stale elnora@elnora-ai in settings.json"
+        }
+    } else {
+        Test-Fail "settings.json not found"
+    }
+
+    $marketplaces = "$claudeDir\plugins\known_marketplaces.json"
+    if (Test-Path $marketplaces) {
+        $mpContent = Get-Content $marketplaces -Raw
+        if ($mpContent -match '"elnora-plugins"') {
+            Test-Pass "known_marketplaces.json has elnora-plugins"
+        } else {
+            Test-Fail "known_marketplaces.json missing elnora-plugins"
+        }
+    } else {
+        Test-Fail "known_marketplaces.json not found"
+    }
+} else {
+    Write-Host "  SKIP: ~/.claude/ not found -- skipping Claude Code setup tests"
+}
+
+# ---------------------------------------------------------------------------
+# 5. SKILL.md files contain Tool Access block
+# ---------------------------------------------------------------------------
+
+$skillsDir = $null
+$candidates = @(
+    "$claudeDir\plugins\marketplaces\elnora-plugins\elnora\skills",
+    "$env:USERPROFILE\.elnora\skills"
+)
+# Also check repo-local skills
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoSkills = Join-Path (Split-Path -Parent $scriptDir) "skills"
+if (Test-Path $repoSkills) { $candidates = @($repoSkills) + $candidates }
+
+foreach ($d in $candidates) {
+    if (Test-Path $d) { $skillsDir = $d; break }
+}
+
+if ($skillsDir) {
+    $skillCount = 0
+    $toolAccessCount = 0
+    Get-ChildItem "$skillsDir\elnora-*\SKILL.md" -ErrorAction SilentlyContinue | ForEach-Object {
+        $skillCount++
+        if ((Get-Content $_.FullName -Raw) -match "## Tool Access") {
+            $toolAccessCount++
+        } else {
+            Test-Fail "Missing Tool Access in $($_.Directory.Name)\SKILL.md"
+        }
+    }
+    if ($skillCount -eq 0) {
+        Test-Fail "No SKILL.md files found in $skillsDir"
+    } elseif ($toolAccessCount -eq $skillCount) {
+        Test-Pass "All $skillCount skills have Tool Access block"
+    }
+} else {
+    Write-Host "  SKIP: No skills directory found"
+}
+
+# ---------------------------------------------------------------------------
+# 6. API connectivity (requires SMOKE_TEST_API_KEY)
+# ---------------------------------------------------------------------------
+
+if ($env:SMOKE_TEST_API_KEY) {
+    & elnora auth login --api-key $env:SMOKE_TEST_API_KEY 2>$null
+
+    $doctorResult = & elnora doctor 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Test-Pass "elnora doctor passes"
+    } else {
+        Test-Fail "elnora doctor failed"
+    }
+
+    $projectsResult = & elnora projects list --compact 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Test-Pass "elnora projects list succeeds"
+    } else {
+        Test-Fail "elnora projects list failed"
+    }
+} else {
+    Write-Host "  SKIP: SMOKE_TEST_API_KEY not set -- skipping API tests"
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "=== Results: $Pass passed, $Fail failed ==="
+
+if ($Fail -gt 0) { exit 1 }

--- a/scripts/smoke-test-carmen.sh
+++ b/scripts/smoke-test-carmen.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Carmen cold-start smoke test
+#
+# Verifies the install → auth → setup → skills flow works end-to-end.
+# Exits non-zero on any failure.
+#
+# Usage:
+#   # Full test (requires SMOKE_TEST_API_KEY env var for auth + API checks):
+#   SMOKE_TEST_API_KEY=elnora_live_xxx ./scripts/smoke-test-carmen.sh
+#
+#   # Structure-only test (skips auth + API — verifies install, PATH, setup, skills):
+#   ./scripts/smoke-test-carmen.sh
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== Carmen cold-start smoke test ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. Binary exists and is executable
+# ---------------------------------------------------------------------------
+
+if command -v elnora >/dev/null 2>&1; then
+  pass "elnora is in PATH"
+else
+  fail "elnora is NOT in PATH"
+  echo "       Searched: $PATH"
+  # Try common install locations as fallback
+  for p in "$HOME/.local/bin/elnora" "/usr/local/bin/elnora"; do
+    if [ -x "$p" ]; then
+      echo "       Found at $p — adding to PATH"
+      export PATH="$(dirname "$p"):$PATH"
+      pass "elnora found at $p (added to PATH)"
+      break
+    fi
+  done
+  if ! command -v elnora >/dev/null 2>&1; then
+    echo ""
+    echo "Cannot continue without elnora binary."
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Version output
+# ---------------------------------------------------------------------------
+
+VERSION=$(elnora --version 2>/dev/null || true)
+if [ -n "$VERSION" ]; then
+  pass "elnora --version → $VERSION"
+else
+  fail "elnora --version returned empty"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. setup-claude alias exists
+# ---------------------------------------------------------------------------
+
+if elnora setup-claude --help >/dev/null 2>&1; then
+  pass "elnora setup-claude command exists"
+else
+  fail "elnora setup-claude command does not exist"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. setup claude writes correct marketplace entries
+# ---------------------------------------------------------------------------
+
+if [ -d "$HOME/.claude" ]; then
+  # Run setup claude (non-destructive — idempotent)
+  elnora setup claude 2>/dev/null || true
+
+  # Check settings.json
+  SETTINGS="$HOME/.claude/settings.json"
+  if [ -f "$SETTINGS" ]; then
+    if grep -q '"elnora@elnora-plugins"' "$SETTINGS"; then
+      pass "settings.json has elnora@elnora-plugins"
+    else
+      fail "settings.json missing elnora@elnora-plugins"
+    fi
+
+    if grep -q '"elnora@elnora-ai"' "$SETTINGS"; then
+      fail "settings.json still has broken elnora@elnora-ai (legacy not cleaned)"
+    else
+      pass "no stale elnora@elnora-ai in settings.json"
+    fi
+  else
+    fail "settings.json not found at $SETTINGS"
+  fi
+
+  # Check known_marketplaces.json
+  MARKETPLACES="$HOME/.claude/plugins/known_marketplaces.json"
+  if [ -f "$MARKETPLACES" ]; then
+    if grep -q '"elnora-plugins"' "$MARKETPLACES"; then
+      pass "known_marketplaces.json has elnora-plugins entry"
+    else
+      fail "known_marketplaces.json missing elnora-plugins entry"
+    fi
+  else
+    fail "known_marketplaces.json not found"
+  fi
+else
+  echo "  SKIP: ~/.claude/ not found — skipping Claude Code setup tests"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. SKILL.md files contain Tool Access block
+# ---------------------------------------------------------------------------
+
+SKILLS_DIR=""
+for d in "$HOME/.claude/plugins/marketplaces/elnora-plugins/elnora/skills" \
+         "$HOME/.elnora/skills"; do
+  if [ -d "$d" ]; then
+    SKILLS_DIR="$d"
+    break
+  fi
+done
+
+# Also check repo-local skills if running from the repo
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_SKILLS="$(dirname "$SCRIPT_DIR")/skills"
+if [ -d "$REPO_SKILLS" ]; then
+  SKILLS_DIR="$REPO_SKILLS"
+fi
+
+if [ -n "$SKILLS_DIR" ]; then
+  SKILL_COUNT=0
+  TOOL_ACCESS_COUNT=0
+  for skill in "$SKILLS_DIR"/elnora-*/SKILL.md; do
+    [ -f "$skill" ] || continue
+    SKILL_COUNT=$((SKILL_COUNT + 1))
+    if grep -q "## Tool Access" "$skill"; then
+      TOOL_ACCESS_COUNT=$((TOOL_ACCESS_COUNT + 1))
+    else
+      fail "Missing Tool Access in $(basename "$(dirname "$skill")")/SKILL.md"
+    fi
+  done
+
+  if [ "$SKILL_COUNT" -eq 0 ]; then
+    fail "No SKILL.md files found in $SKILLS_DIR"
+  elif [ "$TOOL_ACCESS_COUNT" -eq "$SKILL_COUNT" ]; then
+    pass "All $SKILL_COUNT skills have Tool Access block"
+  fi
+else
+  echo "  SKIP: No skills directory found — skipping SKILL.md checks"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. API connectivity (requires SMOKE_TEST_API_KEY)
+# ---------------------------------------------------------------------------
+
+if [ -n "${SMOKE_TEST_API_KEY:-}" ]; then
+  # Configure auth non-interactively
+  elnora auth login --api-key "$SMOKE_TEST_API_KEY" >/dev/null 2>&1 || true
+
+  if elnora doctor >/dev/null 2>&1; then
+    pass "elnora doctor passes"
+  else
+    fail "elnora doctor failed"
+  fi
+
+  if elnora projects list --compact >/dev/null 2>&1; then
+    pass "elnora projects list succeeds"
+  else
+    fail "elnora projects list failed"
+  fi
+else
+  echo "  SKIP: SMOKE_TEST_API_KEY not set — skipping API tests"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/scripts/smoke-test-coldstart.ps1
+++ b/scripts/smoke-test-coldstart.ps1
@@ -1,16 +1,16 @@
 # ---------------------------------------------------------------------------
-# Carmen cold-start smoke test (Windows)
+# Cold-start smoke test (Windows)
 #
 # Verifies the install -> auth -> setup -> skills flow works end-to-end.
 # Exits non-zero on any failure.
 #
 # Usage:
 #   # Full test (requires SMOKE_TEST_API_KEY env var):
-#   $env:SMOKE_TEST_API_KEY = "elnora_live_xxx"
-#   .\scripts\smoke-test-carmen.ps1
+#   $env:SMOKE_TEST_API_KEY = "<your-api-key>"
+#   .\scripts\smoke-test-coldstart.ps1
 #
 #   # Structure-only test (skips auth + API):
-#   .\scripts\smoke-test-carmen.ps1
+#   .\scripts\smoke-test-coldstart.ps1
 # ---------------------------------------------------------------------------
 
 $ErrorActionPreference = "Continue"
@@ -20,7 +20,7 @@ $Fail = 0
 function Test-Pass($msg) { Write-Host "  PASS: $msg"; $script:Pass++ }
 function Test-Fail($msg) { Write-Host "  FAIL: $msg"; $script:Fail++ }
 
-Write-Host "=== Carmen cold-start smoke test (Windows) ==="
+Write-Host "=== Cold-start smoke test (Windows) ==="
 Write-Host ""
 
 # ---------------------------------------------------------------------------

--- a/scripts/smoke-test-coldstart.sh
+++ b/scripts/smoke-test-coldstart.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 # ---------------------------------------------------------------------------
-# Carmen cold-start smoke test
+# Cold-start smoke test
 #
 # Verifies the install → auth → setup → skills flow works end-to-end.
 # Exits non-zero on any failure.
 #
 # Usage:
 #   # Full test (requires SMOKE_TEST_API_KEY env var for auth + API checks):
-#   SMOKE_TEST_API_KEY=elnora_live_xxx ./scripts/smoke-test-carmen.sh
+#   SMOKE_TEST_API_KEY=<your-api-key> ./scripts/smoke-test-coldstart.sh
 #
 #   # Structure-only test (skips auth + API — verifies install, PATH, setup, skills):
-#   ./scripts/smoke-test-carmen.sh
+#   ./scripts/smoke-test-coldstart.sh
 # ---------------------------------------------------------------------------
 
 set -euo pipefail
@@ -21,7 +21,7 @@ FAIL=0
 pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 
-echo "=== Carmen cold-start smoke test ==="
+echo "=== Cold-start smoke test ==="
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/skills/elnora-admin/SKILL.md
+++ b/skills/elnora-admin/SKILL.md
@@ -14,6 +14,23 @@ description: >
 
 Authentication, API key management, account settings, health checks, audit logs, feedback, and shell completions.
 
+## Tool Access
+
+Elnora is a **command-line tool**. Run commands via your Bash/Shell tool.
+
+- **Command:** `elnora`
+- **Verify:** `elnora --version`
+- **If not found:** tell the user to install it. Detect their platform:
+  - macOS/Linux: `curl -fsSL https://cli.elnora.ai/install.sh | bash`
+  - Windows (PowerShell): `irm https://cli.elnora.ai/install.ps1 | iex`
+  - Any platform with Node.js: `npm install -g @elnora-ai/cli`
+
+**CLI is the recommended path** — it uses fewer tokens, is more reliable, and the commands below are ready to copy-paste.
+
+If MCP tools prefixed `mcp__elnora__` are available in your tool list, they work too — use whichever the user prefers or whichever is already configured in your environment.
+
+**Never fabricate function names** like `elnora_generate_protocol`. All valid commands are listed under "Commands" in this skill.
+
 ## Invocation
 
 ```bash

--- a/skills/elnora-agent/SKILL.md
+++ b/skills/elnora-agent/SKILL.md
@@ -14,11 +14,32 @@ description: >
 
 The Elnora Agent is a sandboxed Python environment with ~78 core tools + 2,100 ToolUniverse scientific tools. Interact via `tasks create` and `tasks send` — describe what you need in plain language.
 
-## Quick Start
+## Tool Access
+
+Elnora is a **command-line tool**. Run commands via your Bash/Shell tool.
+
+- **Command:** `elnora`
+- **Verify:** `elnora --version`
+- **If not found:** tell the user to install it. Detect their platform:
+  - macOS/Linux: `curl -fsSL https://cli.elnora.ai/install.sh | bash`
+  - Windows (PowerShell): `irm https://cli.elnora.ai/install.ps1 | iex`
+  - Any platform with Node.js: `npm install -g @elnora-ai/cli`
+
+**CLI is the recommended path** — it uses fewer tokens, is more reliable, and the commands below are ready to copy-paste.
+
+If MCP tools prefixed `mcp__elnora__` are available in your tool list, they work too — use whichever the user prefers or whichever is already configured in your environment.
+
+**Never fabricate function names** like `elnora_generate_protocol`. All valid commands are listed under "Commands" in this skill.
+
+## Invocation
 
 ```bash
 CLI="elnora"
+```
 
+## Quick Start
+
+```bash
 # Create a task and wait for the response
 $CLI --compact tasks create --project <PROJECT_ID> --title "My task" --message "Your request"
 

--- a/skills/elnora-files/SKILL.md
+++ b/skills/elnora-files/SKILL.md
@@ -12,6 +12,23 @@ description: >
 
 Browse, read, create, upload, version, and manage files on the Elnora AI Platform.
 
+## Tool Access
+
+Elnora is a **command-line tool**. Run commands via your Bash/Shell tool.
+
+- **Command:** `elnora`
+- **Verify:** `elnora --version`
+- **If not found:** tell the user to install it. Detect their platform:
+  - macOS/Linux: `curl -fsSL https://cli.elnora.ai/install.sh | bash`
+  - Windows (PowerShell): `irm https://cli.elnora.ai/install.ps1 | iex`
+  - Any platform with Node.js: `npm install -g @elnora-ai/cli`
+
+**CLI is the recommended path** — it uses fewer tokens, is more reliable, and the commands below are ready to copy-paste.
+
+If MCP tools prefixed `mcp__elnora__` are available in your tool list, they work too — use whichever the user prefers or whichever is already configured in your environment.
+
+**Never fabricate function names** like `elnora_generate_protocol`. All valid commands are listed under "Commands" in this skill.
+
 ## Invocation
 
 ```bash

--- a/skills/elnora-folders/SKILL.md
+++ b/skills/elnora-folders/SKILL.md
@@ -10,6 +10,23 @@ description: >
 
 Manage the folder tree within Elnora projects.
 
+## Tool Access
+
+Elnora is a **command-line tool**. Run commands via your Bash/Shell tool.
+
+- **Command:** `elnora`
+- **Verify:** `elnora --version`
+- **If not found:** tell the user to install it. Detect their platform:
+  - macOS/Linux: `curl -fsSL https://cli.elnora.ai/install.sh | bash`
+  - Windows (PowerShell): `irm https://cli.elnora.ai/install.ps1 | iex`
+  - Any platform with Node.js: `npm install -g @elnora-ai/cli`
+
+**CLI is the recommended path** — it uses fewer tokens, is more reliable, and the commands below are ready to copy-paste.
+
+If MCP tools prefixed `mcp__elnora__` are available in your tool list, they work too — use whichever the user prefers or whichever is already configured in your environment.
+
+**Never fabricate function names** like `elnora_generate_protocol`. All valid commands are listed under "Commands" in this skill.
+
 ## Invocation
 
 ```bash

--- a/skills/elnora-orgs/SKILL.md
+++ b/skills/elnora-orgs/SKILL.md
@@ -12,6 +12,23 @@ description: >
 
 Manage organizations, members, billing, invitations, and the shared organization library.
 
+## Tool Access
+
+Elnora is a **command-line tool**. Run commands via your Bash/Shell tool.
+
+- **Command:** `elnora`
+- **Verify:** `elnora --version`
+- **If not found:** tell the user to install it. Detect their platform:
+  - macOS/Linux: `curl -fsSL https://cli.elnora.ai/install.sh | bash`
+  - Windows (PowerShell): `irm https://cli.elnora.ai/install.ps1 | iex`
+  - Any platform with Node.js: `npm install -g @elnora-ai/cli`
+
+**CLI is the recommended path** — it uses fewer tokens, is more reliable, and the commands below are ready to copy-paste.
+
+If MCP tools prefixed `mcp__elnora__` are available in your tool list, they work too — use whichever the user prefers or whichever is already configured in your environment.
+
+**Never fabricate function names** like `elnora_generate_protocol`. All valid commands are listed under "Commands" in this skill.
+
 ## Invocation
 
 ```bash

--- a/skills/elnora-platform/SKILL.md
+++ b/skills/elnora-platform/SKILL.md
@@ -12,6 +12,23 @@ description: >
 
 Route Elnora Platform queries to the correct sub-skill. Load only what is needed.
 
+## Tool Access
+
+Elnora is a **command-line tool**. Run commands via your Bash/Shell tool.
+
+- **Command:** `elnora`
+- **Verify:** `elnora --version`
+- **If not found:** tell the user to install it. Detect their platform:
+  - macOS/Linux: `curl -fsSL https://cli.elnora.ai/install.sh | bash`
+  - Windows (PowerShell): `irm https://cli.elnora.ai/install.ps1 | iex`
+  - Any platform with Node.js: `npm install -g @elnora-ai/cli`
+
+**CLI is the recommended path** — it uses fewer tokens, is more reliable, and the commands below are ready to copy-paste.
+
+If MCP tools prefixed `mcp__elnora__` are available in your tool list, they work too — use whichever the user prefers or whichever is already configured in your environment.
+
+**Never fabricate function names** like `elnora_generate_protocol`. All valid commands are listed under "Commands" in this skill.
+
 ## Invocation
 
 ```bash

--- a/skills/elnora-projects/SKILL.md
+++ b/skills/elnora-projects/SKILL.md
@@ -11,6 +11,23 @@ description: >
 
 Manage projects on the Elnora AI Platform. Projects are containers for tasks, files, and folders.
 
+## Tool Access
+
+Elnora is a **command-line tool**. Run commands via your Bash/Shell tool.
+
+- **Command:** `elnora`
+- **Verify:** `elnora --version`
+- **If not found:** tell the user to install it. Detect their platform:
+  - macOS/Linux: `curl -fsSL https://cli.elnora.ai/install.sh | bash`
+  - Windows (PowerShell): `irm https://cli.elnora.ai/install.ps1 | iex`
+  - Any platform with Node.js: `npm install -g @elnora-ai/cli`
+
+**CLI is the recommended path** — it uses fewer tokens, is more reliable, and the commands below are ready to copy-paste.
+
+If MCP tools prefixed `mcp__elnora__` are available in your tool list, they work too — use whichever the user prefers or whichever is already configured in your environment.
+
+**Never fabricate function names** like `elnora_generate_protocol`. All valid commands are listed under "Commands" in this skill.
+
 ## Invocation
 
 ```bash

--- a/skills/elnora-search/SKILL.md
+++ b/skills/elnora-search/SKILL.md
@@ -12,6 +12,23 @@ description: >
 
 Search tasks, files, or all resources across projects by keyword.
 
+## Tool Access
+
+Elnora is a **command-line tool**. Run commands via your Bash/Shell tool.
+
+- **Command:** `elnora`
+- **Verify:** `elnora --version`
+- **If not found:** tell the user to install it. Detect their platform:
+  - macOS/Linux: `curl -fsSL https://cli.elnora.ai/install.sh | bash`
+  - Windows (PowerShell): `irm https://cli.elnora.ai/install.ps1 | iex`
+  - Any platform with Node.js: `npm install -g @elnora-ai/cli`
+
+**CLI is the recommended path** — it uses fewer tokens, is more reliable, and the commands below are ready to copy-paste.
+
+If MCP tools prefixed `mcp__elnora__` are available in your tool list, they work too — use whichever the user prefers or whichever is already configured in your environment.
+
+**Never fabricate function names** like `elnora_generate_protocol`. All valid commands are listed under "Commands" in this skill.
+
 ## Invocation
 
 ```bash

--- a/skills/elnora-tasks/SKILL.md
+++ b/skills/elnora-tasks/SKILL.md
@@ -11,6 +11,29 @@ description: >
 
 Tasks are conversations with the Elnora AI Agent. Send messages to generate protocols, iterate on outputs, and reference uploaded files.
 
+## Tool Access
+
+Elnora is a **command-line tool**. Run commands via your Bash/Shell tool.
+
+- **Command:** `elnora`
+- **Verify:** `elnora --version`
+- **If not found:** tell the user to install it. Detect their platform:
+  - macOS/Linux: `curl -fsSL https://cli.elnora.ai/install.sh | bash`
+  - Windows (PowerShell): `irm https://cli.elnora.ai/install.ps1 | iex`
+  - Any platform with Node.js: `npm install -g @elnora-ai/cli`
+
+**CLI is the recommended path** — it uses fewer tokens, is more reliable, and the commands below are ready to copy-paste.
+
+If MCP tools prefixed `mcp__elnora__` are available in your tool list, they work too — use whichever the user prefers or whichever is already configured in your environment.
+
+**Never fabricate function names** like `elnora_generate_protocol`. All valid commands are listed under "Commands" in this skill.
+
+## Invocation
+
+```bash
+CLI="elnora"
+```
+
 ## Response Retrieval
 
 The Elnora backend processes agent responses asynchronously. When you send a message, the POST returns immediately with the user message echo — the AI response arrives separately. Use `--stream` or `--wait` to collect it.
@@ -50,12 +73,6 @@ elnora --compact --fields "id,name" projects list
 ```
 
 Pick the project that best matches the user's request by name. If there's only one project, use it. If unsure, ask the user which project to use. **Remember the project ID** — don't re-list projects for every task command.
-
-## Invocation
-
-```bash
-CLI="elnora"
-```
 
 ## Commands
 

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -121,4 +121,14 @@ export function addSetupCommand(program: Command): void {
 		const platforms = installed.map((p) => p.name as PlatformName);
 		runSetup(platforms, opts.profile);
 	});
+
+	// Top-level alias: `elnora setup-claude` → `elnora setup claude`
+	program
+		.command("setup-claude")
+		.description("Set up Claude Code (alias for 'setup claude')")
+		.option("--profile <name>", "API key profile to use", "default")
+		.action((opts: { profile: string }) => {
+			console.error("");
+			runSetup(["claude"], opts.profile);
+		});
 }

--- a/src/lib/setup/common.ts
+++ b/src/lib/setup/common.ts
@@ -34,13 +34,13 @@ export const CODEX_DIR = join(HOME, ".codex");
 // Marketplace / Plugin IDs
 // ---------------------------------------------------------------------------
 
-export const MARKETPLACE_NAME = "elnora-ai";
+export const MARKETPLACE_NAME = "elnora-plugins";
 export const MARKETPLACE_REPO = "Elnora-AI/elnora-plugins";
 export const PLUGIN_ID = `elnora@${MARKETPLACE_NAME}`;
 
 /** Old IDs to clean up from previous setup-claude versions. */
-export const LEGACY_PLUGIN_IDS = ["elnora@elnora-local"];
-export const LEGACY_MARKETPLACE_NAMES = ["elnora-local"];
+export const LEGACY_PLUGIN_IDS = ["elnora@elnora-local", "elnora@elnora-ai"];
+export const LEGACY_MARKETPLACE_NAMES = ["elnora-local", "elnora-ai"];
 
 // ---------------------------------------------------------------------------
 // JSON helpers


### PR DESCRIPTION
## Summary

Fixes 5 urgent bugs Carmen found when testing CLI v1.3.4 that each independently break the install-to-use flow for non-developer users (biologists).

- **ELN-630**: `MARKETPLACE_NAME` was `"elnora-ai"` but actual marketplace is `"elnora-plugins"` — skills never loaded in Claude Code
- **ELN-627**: `elnora setup-claude` didn't exist (only `elnora setup claude` subcommand) — install.sh told users to run a nonexistent command
- **ELN-629**: Install scripts only printed PATH advice instead of auto-configuring; no auto-setup of AI tools; post-install referenced broken `setup-claude` command
- **ELN-631**: SKILL.md files assumed the agent already knew Elnora was a CLI tool — agents guessed MCP tool names and failed
- **ELN-628**: README had zero mention of skills, setup, or what to do after install

Also fixes 25 pre-existing Biome lint/format errors (18 CRLF line endings + 2 unused imports) by adding `.gitattributes` with `eol=lf`.

## Changes

| File | What |
|------|------|
| `src/lib/setup/common.ts` | Fix `MARKETPLACE_NAME` to `"elnora-plugins"`, add `"elnora-ai"` to legacy cleanup |
| `src/commands/setup.ts` | Add `setup-claude` top-level alias |
| `install.sh` | Auto-append PATH to shell rc, auto-run `elnora setup`, success banner |
| `install.ps1` | Same for Windows + fix current-session PATH update |
| `skills/elnora-*/SKILL.md` (9 files) | Add Tool Access block with install instructions and CLI-preferred guidance |
| `README.md` | Add Skills & Setup section, Where Everything Lives, manual recovery path |
| `scripts/smoke-test-carmen.sh` | Cold-start smoke test (macOS/Linux) |
| `scripts/smoke-test-carmen.ps1` | Cold-start smoke test (Windows) |
| `.gitattributes` | Enforce LF for source files, CRLF for .ps1 |
| `__tests__/lib/prompt.test.ts` | Remove unused `vi` import, prefix unused variable |

## Test plan

- [x] 554/554 unit tests pass (`pnpm test`)
- [x] TypeScript typecheck clean (`pnpm run typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Biome lint fully clean — 0 errors (`npx biome check src/ __tests__/`)
- [x] Manual: `elnora setup claude` writes `"elnora@elnora-plugins"` and cleans stale `"elnora@elnora-ai"`
- [x] Manual: `elnora setup-claude` alias produces identical result
- [x] Smoke test: 6/7 pass locally (1 expected failure — system binary is still v1.3.4)
- [x] All 9 SKILL.md files verified to have Tool Access block
- [ ] After merge + release: verify install scripts on clean macOS/Linux/Windows
- [ ] After merge + release: verify skills sync to elnora-plugins repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)