### PR TITLE
fix(doctor): unbreak plugin-version test across release bumps

### DIFF
--- a/__tests__/commands/doctor.test.ts
+++ b/__tests__/commands/doctor.test.ts
@@ -137,8 +137,11 @@ describe("elnora doctor", () => {
 		// Verify the Claude Code section reports clean results
 		expect(output).toMatch(/✓[^\n]*Plugin enabled.*elnora@elnora-plugins/);
 		expect(output).toMatch(/✓[^\n]*Skills installed.*9 skills/);
-		const versionPattern = new RegExp(`✓[^\\n]*Plugin version.*v${VERSION.replace(/\./g, "\\.")} \\(matches CLI\\)`);
-		expect(output).toMatch(versionPattern);
+		// Split the Plugin version check into a structure match + a literal
+		// substring check so we don't have to build a regex from VERSION
+		// (avoids regex-escaping pitfalls flagged by CodeQL).
+		expect(output).toMatch(/✓[^\n]*Plugin version/);
+		expect(output).toContain(`v${VERSION} (matches CLI)`);
 		capture.restore();
 	});
 

--- a/__tests__/commands/doctor.test.ts
+++ b/__tests__/commands/doctor.test.ts
@@ -13,6 +13,7 @@ vi.mock("node:os", async () => {
 
 // Dynamic import after mock so constants are built with mocked homedir
 const { addDoctorCommand } = await import("../../src/commands/doctor.js");
+const { VERSION } = await import("../../src/lib/config.js");
 
 // Helper to capture console.error output
 function captureStderr() {
@@ -123,7 +124,9 @@ describe("elnora doctor", () => {
 		writeFileSync(join(claude, "settings.json"), JSON.stringify({ enabledPlugins: { "elnora@elnora-plugins": true } }));
 		writeFileSync(
 			join(claude, "plugins", "marketplaces", "elnora-plugins", "elnora", ".claude-plugin", "plugin.json"),
-			JSON.stringify({ version: "1.3.5" }),
+			// Match the CLI version so the "Plugin version" check reports (matches CLI).
+			// Using VERSION dynamically keeps the test valid across release-please bumps.
+			JSON.stringify({ version: VERSION }),
 		);
 
 		const capture = captureStderr();
@@ -134,7 +137,8 @@ describe("elnora doctor", () => {
 		// Verify the Claude Code section reports clean results
 		expect(output).toMatch(/✓[^\n]*Plugin enabled.*elnora@elnora-plugins/);
 		expect(output).toMatch(/✓[^\n]*Skills installed.*9 skills/);
-		expect(output).toMatch(/✓[^\n]*Plugin version.*v1\.3\.5 \(matches CLI\)/);
+		const versionPattern = new RegExp(`✓[^\\n]*Plugin version.*v${VERSION.replace(/\./g, "\\.")} \\(matches CLI\\)`);
+		expect(output).toMatch(versionPattern);
 		capture.restore();
 	});
 


### PR DESCRIPTION
## Summary

The release-please PR is failing `Lint & Test` because the doctor test hardcodes `"1.3.5"` for `plugin.json` version and asserts a literal `v1.3.5 (matches CLI)`. When the CLI bumps to 1.4.0 the regex no longer matches.

Read `VERSION` from `src/lib/config.js` so the plugin fixture and the regex track `package.json`. No product code changes; test-only fix.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (564 passing)
- [ ] CI `Lint & Test` green on this PR
- [ ] release-please PR #103 auto-rebases and its CI goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)