### PR TITLE
feat(ci): lint PR titles to conventional-commits format

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,32 @@
+name: PR Title Lint
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Conventional Commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            ci
+            refactor
+            perf
+            test
+            revert
+            build
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: "PR title must not be empty after the type prefix."


### PR DESCRIPTION
## Summary
Adds a GitHub Action that checks every PR's title against the conventional-commits format (\`feat\`, \`fix\`, \`chore\`, etc.) before it can be merged. Mirrors the same workflow already running on \`elnora-mcp-server\`.

## Why
When a PR is squash-merged with a non-conventional title (e.g. #105's \`Add MCP tool parity audit + CI check (v1.5.0)\`), the resulting commit on \`main\` is also non-conventional. Release-please skips it, so the work sits on main without a release bump.

This check runs on every PR and blocks merging until the title is fixed.

## Allowed types
feat, fix, chore, docs, ci, refactor, perf, test, revert, build

🤖 Generated with [Claude Code](https://claude.com/claude-code)