### PR TITLE
fix(installer): Windows ARM64 build + iex-safe error handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
           - os: windows-latest
             target: win-x64
             binary: elnora-win-x64.exe
+          - os: windows-latest
+            target: win-arm64
+            binary: elnora-win-arm64.exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +52,7 @@ jobs:
           # Copy skills into dist/ for bundling
           cp -r skills dist/skills
           cd dist
-          if [[ "${{ matrix.target }}" == "win-x64" ]]; then
+          if [[ "${{ matrix.target }}" == win-* ]]; then
             7z a ${{ matrix.binary }}.zip ${{ matrix.binary }} skills
           else
             tar -czf ${{ matrix.binary }}.tar.gz ${{ matrix.binary }} skills
@@ -59,7 +62,7 @@ jobs:
         shell: bash
         run: |
           cd dist
-          if [[ "${{ matrix.target }}" == "win-x64" ]]; then
+          if [[ "${{ matrix.target }}" == win-* ]]; then
             ARCHIVE="${{ matrix.binary }}.zip"
           else
             ARCHIVE="${{ matrix.binary }}.tar.gz"
@@ -111,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/install.ps1
+++ b/install.ps1
@@ -25,13 +25,13 @@ if (-not $Version) {
         Write-Host ""
         Write-Host "Error: Could not fetch the latest version. Check your internet connection." -ForegroundColor Red
         Write-Host "  Retry, or pin a version: irm https://cli.elnora.ai/install.ps1 | iex -Version v<VERSION>"
-        exit 1
+        throw "Could not fetch the latest version."
     }
     if (-not $Version) {
         Write-Host ""
         Write-Host "Error: Could not determine the latest version." -ForegroundColor Red
         Write-Host "  Check releases: https://github.com/$Repo/releases"
-        exit 1
+        throw "Could not determine the latest version."
     }
 }
 
@@ -48,20 +48,39 @@ try {
     Write-Host ""
     Write-Host "Error: Could not create directory: $InstallDir" -ForegroundColor Red
     Write-Host "  Try running PowerShell as Administrator."
-    exit 1
+    throw "Could not create install directory: $InstallDir"
 }
 
 # Download
 $TmpDir = New-TemporaryFile | ForEach-Object { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
 
+# Try the native build first. If ARM64 asset is missing for this release,
+# fall back to x64 — Windows 11 on ARM runs x64 binaries transparently.
+$downloadOk = $false
 try {
     Invoke-WebRequest -Uri $DownloadUrl -OutFile "$TmpDir\$Target.zip" -TimeoutSec 120
+    $downloadOk = $true
 } catch {
+    if ($Arch -eq "arm64") {
+        Write-Host "  Note: native arm64 build not available for $Version; falling back to x64 (runs via Windows on ARM emulation)."
+        $Arch = "x64"
+        $Target = "elnora-win-$Arch.exe"
+        $DownloadUrl = "https://github.com/$Repo/releases/download/$Version/$Target.zip"
+        $ChecksumUrl = "https://github.com/$Repo/releases/download/$Version/$Target.sha256"
+        try {
+            Invoke-WebRequest -Uri $DownloadUrl -OutFile "$TmpDir\$Target.zip" -TimeoutSec 120
+            $downloadOk = $true
+        } catch {
+            # Fall through to the error branch below.
+        }
+    }
+}
+if (-not $downloadOk) {
     Write-Host ""
     Write-Host "Error: Failed to download Elnora CLI $Version for win-$Arch." -ForegroundColor Red
     Write-Host "  Check that this version exists: https://github.com/$Repo/releases/tag/$Version"
     Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
-    exit 1
+    throw "Failed to download Elnora CLI $Version for win-$Arch."
 }
 
 $SkipChecksum = $false
@@ -89,7 +108,7 @@ if (-not $SkipChecksum) {
             Write-Host "  Got:      $actual"
             Write-Host "  Try running the installer again: irm https://cli.elnora.ai/install.ps1 | iex"
             Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
-            exit 1
+            throw "Checksum verification failed for $Target.zip."
         }
     }
 }
@@ -102,7 +121,7 @@ try {
     Write-Host "Error: Failed to extract archive. The download may be corrupted." -ForegroundColor Red
     Write-Host "  Try running the installer again: irm https://cli.elnora.ai/install.ps1 | iex"
     Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
-    exit 1
+    throw "Failed to extract $Target.zip."
 }
 
 if (-not (Test-Path "$TmpDir\$Target")) {
@@ -110,7 +129,7 @@ if (-not (Test-Path "$TmpDir\$Target")) {
     Write-Host "Error: Binary not found after extraction. The release archive may be incomplete." -ForegroundColor Red
     Write-Host "  Report this issue: https://github.com/$Repo/issues"
     Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
-    exit 1
+    throw "Binary missing after extraction: $Target."
 }
 
 # Install
@@ -125,7 +144,7 @@ try {
         Write-Host "  Try running PowerShell as Administrator."
     }
     Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
-    exit 1
+    throw "Failed to copy elnora.exe to $InstallDir."
 }
 
 # Add to PATH — persist AND update current session


### PR DESCRIPTION
## Summary

Two fixes in `install.ps1` and the release pipeline:

1. **Windows ARM64 release asset.** v1.5.0 ships `linux-arm64`, `macos-arm64`, and `win-x64` but no `win-arm64`. `install.ps1` detects ARM64 and constructs a 404 download URL.
2. **`exit 1` propagation through `iex`.** The 8 `exit 1` statements in `install.ps1` run in the caller's scope when the script is piped through `iex`, so a parent script cannot catch the failure with `try/catch`.

Closes ELN-650.

## What changed

**`.github/workflows/release.yml`**
- Added `win-arm64` to the build matrix (cross-compiled on `windows-latest` with `--target node20-win-arm64`).
- Generalised the archive + SHA256 condition from `"win-x64"` exact match to a `win-*` glob so the new target ships a `.zip` like its sibling.
- Added `windows-11-arm` to the smoke-test matrix.

**`install.ps1`**
- Replaced 8 `exit 1` calls with `throw "..."` so callers piping through `iex` can catch failures.
- Added a transparent x64 fallback: if the win-arm64 asset is missing for the requested version, the installer retries with `win-x64`. Windows 11 on ARM runs x64 binaries via Prism translation.

## Test plan

- [x] `pnpm typecheck` clean.
- [ ] CI build produces `elnora-win-arm64.exe.zip` + `.sha256` on the new matrix entry.
- [ ] CI smoke test passes on `windows-11-arm`.
- [ ] Manual install via `irm https://cli.elnora.ai/install.ps1 | iex` on a Windows ARM64 device after release.

## Risk

`throw` does not set `$LASTEXITCODE`. Consumers relying on `$LASTEXITCODE` after piping this script through `iex` need to read `$?` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)