### PR TITLE
fix(release): unblock v1.5.x publishing + Windows spawn resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
   build-binaries:
     name: Build ${{ matrix.binary }}
     strategy:
+      # Don't cancel the rest of the matrix if one arch fails. A single
+      # cross-compile blip should not block npm publish, homebrew update,
+      # or skill sync for the other 5 working artifacts.
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -29,7 +33,11 @@ jobs:
           - os: windows-latest
             target: win-x64
             binary: elnora-win-x64.exe
-          - os: windows-latest
+          # win-arm64 must build on a native ARM64 runner. pkg fabricates the
+          # binary by spawning it during packaging — Windows on x64 cannot
+          # execute ARM64 EXEs (no Prism on the x64 host side), so cross-
+          # compile from windows-latest fails with `spawn UNKNOWN`.
+          - os: windows-11-arm
             target: win-arm64
             binary: elnora-win-arm64.exe
     runs-on: ${{ matrix.os }}

--- a/__tests__/lib/setup/claude.test.ts
+++ b/__tests__/lib/setup/claude.test.ts
@@ -17,11 +17,11 @@ vi.mock("node:os", async () => {
 type SpawnOutcome = { kind: "exit"; code: number } | { kind: "error"; err: NodeJS.ErrnoException };
 
 let nextOutcomes: SpawnOutcome[] = [];
-const spawnCalls: { file: string; args: readonly string[] }[] = [];
+const spawnCalls: { file: string; args: readonly string[]; options: { shell?: boolean | string } }[] = [];
 
 vi.mock("node:child_process", () => ({
-	spawn: (file: string, args: readonly string[], _options: unknown) => {
-		spawnCalls.push({ file, args });
+	spawn: (file: string, args: readonly string[], options: { shell?: boolean | string }) => {
+		spawnCalls.push({ file, args, options });
 		const ee = new EventEmitter();
 		const outcome: SpawnOutcome = nextOutcomes.shift() ?? { kind: "exit", code: 0 };
 		// Defer event emission to next microtask so the caller can attach listeners.
@@ -91,6 +91,20 @@ describe("setupClaude", () => {
 		const result = await setupClaude();
 		expect(result).toBe(false);
 		expect(spawnCalls).toHaveLength(1);
+	});
+
+	test("passes shell:true to spawn on Windows for .cmd file resolution", async () => {
+		mkdirSync(join(TEST_HOME, ".claude"), { recursive: true });
+
+		const result = await setupClaude();
+		expect(result).toBe(true);
+
+		// On Windows, npm installs CLIs as `<name>.cmd` and Node's CreateProcess-based
+		// spawn won't auto-resolve them. shell: true routes through cmd.exe + PATHEXT,
+		// which finds both .exe (native installer) and .cmd (npm install) variants.
+		const expectedShell = process.platform === "win32";
+		expect(spawnCalls[0].options.shell).toBe(expectedShell);
+		expect(spawnCalls[1].options.shell).toBe(expectedShell);
 	});
 
 	test("returns false if plugin install fails after successful marketplace add", async () => {

--- a/src/lib/setup/claude.ts
+++ b/src/lib/setup/claude.ts
@@ -24,10 +24,19 @@ interface ExecError extends Error {
  * (clone, validation, success ✓) instead of a 30-120s frozen prompt. Resolves
  * on exit code 0; rejects with `code: "ENOENT"` if `claude` isn't on PATH or
  * `code: <number>` for a non-zero exit.
+ *
+ * `shell: true` on Windows because npm installs CLIs as `<name>.cmd` (a batch
+ * file), and Node's CreateProcess-based spawn won't auto-resolve `.cmd` files
+ * — only `.exe`/`.com`. Routing through `cmd.exe` makes PATHEXT do the lookup,
+ * which finds both `claude.exe` (native installer) and `claude.cmd` (npm).
+ * Args are hard-coded URLs/IDs, so no shell-injection surface.
  */
 function runClaudeCli(args: string[]): Promise<void> {
 	return new Promise((resolve, reject) => {
-		const child = spawn("claude", args, { stdio: "inherit" });
+		const child = spawn("claude", args, {
+			stdio: "inherit",
+			shell: process.platform === "win32",
+		});
 		child.on("error", (err) => reject(err));
 		child.on("close", (code) => {
 			if (code === 0) {


### PR DESCRIPTION
## Summary

Two related fixes: restore the release pipeline (matrix entries no longer cancel each other when one arch fails) and make `elnora setup claude` find `claude` on Windows when it was installed via npm.

### 1. Release pipeline (`.github/workflows/release.yml`)

The win-arm64 cross-compile on a `windows-latest` (x64) runner breaks `pkg`'s fabrication step because Windows x64 cannot execute the freshly-built ARM64 EXE that `pkg` spawns to embed the JS snapshot. With the matrix's default `fail-fast: true`, that failure cancels the rest of the matrix and skips the dependent publish jobs.

- **`fail-fast: false`** so a single arch failure can't cancel the others.
- **`os: windows-11-arm`** for win-arm64 — native ARM64 partner runner can execute the binary `pkg` spawns.

### 2. Windows spawn resolution (`src/lib/setup/claude.ts`)

`spawn("claude", args)` without `shell: true` doesn't find `.cmd` files on Windows — Node's CreateProcess-based path lookup only auto-resolves `.exe`/`.com`. npm installs CLIs as `<name>.cmd`, so machines where Claude Code was installed via npm would ENOENT.

- **`shell: process.platform === "win32"`** on the spawn call. Routes through `cmd.exe` so PATHEXT covers both `claude.exe` (native installer) and `claude.cmd` (npm install). Args are hard-coded — no shell-injection surface.

## Test plan

- [x] `pnpm typecheck`, `pnpm test` (575/575), `pnpm lint` — clean.
- [ ] After release: verify the build matrix completes and the publish jobs run.
- [ ] After release: manual `elnora setup claude` on Windows with npm-installed Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)