### PR TITLE
fix(scrub): allow long pure-letter strings to pass through

### DIFF
--- a/__tests__/lib/errors.test.ts
+++ b/__tests__/lib/errors.test.ts
@@ -105,9 +105,16 @@ describe("Credential scrubbing", () => {
 		expect(scrub(input)).toBe("key is [REDACTED]");
 	});
 
-	test("scrubs long token-like strings (40+ chars)", () => {
-		const longToken = "a".repeat(45);
+	test("scrubs long token-like strings (40+ chars with digits)", () => {
+		const longToken = "abc123def456ghi789jkl012mno345pqr678stu901";
 		expect(scrub(`token: ${longToken}`)).toBe("token: [REDACTED]");
+	});
+
+	test("does not scrub long pure-letter strings (e.g. biological sequences)", () => {
+		const dna = "ATGAGCATGCTGTTTTACACCCTGATCACCGCATTTCTGATTGGCATT";
+		expect(scrub(`sequence: ${dna}`)).toBe(`sequence: ${dna}`);
+		const protein = "MSMLFYTLITAFLIGIQAEPLWNSIEQLQSMETSQVQGSGSAGQNIK";
+		expect(scrub(`peptide: ${protein}`)).toBe(`peptide: ${protein}`);
 	});
 
 	test("scrubs key=value patterns", () => {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -103,7 +103,13 @@ export function scrub(text: string): string {
 		}
 	}
 	result = result.replace(SCRUB_KEY_VALUE_RE, "[REDACTED]");
-	result = result.replace(SCRUB_LONG_TOKEN_RE, "[REDACTED]");
+	result = result.replace(SCRUB_LONG_TOKEN_RE, (match) => {
+		// Always redact prefixed API tokens.
+		if (match.startsWith("elnora_live_")) return "[REDACTED]";
+		// For the generic long-token branch, require at least one digit so that
+		// long pure-letter strings (e.g. biological sequences) are not redacted.
+		return /\d/.test(match) ? "[REDACTED]" : match;
+	});
 	return result;
 }
 


### PR DESCRIPTION
## Summary

Narrow the credential scrubber so long pure-letter strings (40+ chars, no digits) are not redacted as tokens. Real API tokens contain digits, so requiring one before redacting on the generic branch removes a false-positive class while preserving coverage of actual credentials.

## Change

- Generic 40+ char token-shape now requires at least one digit before being redacted.
- The `elnora_live_*` prefixed branch is unchanged — still always redacted.
- Existing test updated to use a realistic token; added a test for long pure-letter input.

## Test plan

- [x] `pnpm test` passes
- [x] `pnpm lint` clean

Closes ELN-677