### PR TITLE
chore(ci): clean up Dependabot commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     labels:
       - "dependencies"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"
 
   - package-ecosystem: "github-actions"
@@ -25,5 +25,5 @@ updates:
     labels:
       - "dependencies"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Summary

`prefix: "chore(deps)"` → `prefix: "chore"`. Drops a redundant scope layer so Dependabot's own `(deps)` / `(deps-dev)` scope inference is the only thing producing parens in PR titles.

Was producing `chore(deps)(deps-dev): Bump …`; now produces `chore(deps-dev): Bump …`.