### PR TITLE
feat!: drop Node 20 support, require Node 22+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - name: Audit dependencies
@@ -47,7 +47,7 @@ jobs:
           package_json_file: elnora-cli/package.json
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
           cache-dependency-path: elnora-cli/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
@@ -68,7 +68,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,13 +46,13 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: node scripts/build.mjs
 
       - name: Build binary
-        run: npx pkg dist/cli.cjs --target node20-${{ matrix.target }} --output dist/${{ matrix.binary }}
+        run: npx pkg dist/cli.cjs --target node22-${{ matrix.target }} --output dist/${{ matrix.binary }}
 
       - name: Archive
         shell: bash
@@ -101,7 +101,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
       - name: Sync version from release tag
@@ -129,7 +129,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Extract version from tag
         id: ver

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"LICENSE"
 	],
 	"engines": {
-		"node": ">=20"
+		"node": ">=22"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Bumps the Node minimum to 22 (current active LTS line, supported through April 2027).

Node 20 reached end-of-life on 2026-04-30, so this aligns the engines field, CI, and release jobs on a still-supported runtime.

## Changes

- \`package.json\`: \`engines.node\` \`>=20\` → \`>=22\`
- \`ci.yml\`: 3 jobs, \`node-version\` \`20\` → \`22\`
- \`release.yml\`: build-binaries + smoke-test \`node-version\` \`20\` → \`22\`
- \`release.yml\`: pkg \`--target node20-*\` → \`node22-*\`
- \`release.yml\`: publish-npm \`node-version\` \`24\` → \`22\` (consistency with the rest of the file)

\`dep-batch-review.yml\` stays on Node 24 — that's a CI-only workflow, not user-facing.

## Release impact

This is a \`feat!:\` (breaking change in conventional-commits), so release-please will cut this as \`v2.0.0\` on merge.

For end users: \`npm install -g\` on Node 20 will see a \`npm warn EBADENGINE\` and runtime errors if any Node 22+ APIs are exercised. Homebrew binary installs are unaffected (the binary bundles its own Node 22 runtime via pkg).

## Test plan

- [x] \`pkg --target node22-*\` is supported by \`@yao-pkg/pkg\` 6.19.x (current pinned version)
- [ ] CI passes on this branch
- [ ] After merge, release-please opens the v2.0.0 release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)