### PR TITLE
fix(orgs): use stripeCustomerId in set-stripe wire payload

### DIFF
--- a/__tests__/commands/orgs/orgs.test.ts
+++ b/__tests__/commands/orgs/orgs.test.ts
@@ -282,20 +282,20 @@ describe("orgs.setStripe", () => {
 	test("accepts non-UUID Stripe customer ID", () => {
 		const parsed = orgsSetStripe.inputSchema.parse({
 			orgId: ORG_ID,
-			customerId: "cus_abc123xyz",
+			stripeCustomerId: "cus_abc123xyz",
 		});
-		expect(parsed.customerId).toBe("cus_abc123xyz");
+		expect(parsed.stripeCustomerId).toBe("cus_abc123xyz");
 	});
 
-	test("calls PUT /organizations/{id}/stripe-customer", async () => {
-		const ctx = mockContext({ putResult: { customerId: "cus_abc" } });
-		const result = await orgsSetStripe.execute({ orgId: ORG_ID, customerId: "cus_abc" }, ctx);
+	test("calls PUT /organizations/{id}/stripe-customer with stripeCustomerId field", async () => {
+		const ctx = mockContext({ putResult: { id: ORG_ID, stripeCustomerId: "cus_abc" } });
+		const result = await orgsSetStripe.execute({ orgId: ORG_ID, stripeCustomerId: "cus_abc" }, ctx);
 		expect(ctx.client.put).toHaveBeenCalledWith(
 			"organization_stripe_customer",
-			{ customerId: "cus_abc" },
+			{ stripeCustomerId: "cus_abc" },
 			{ pathParams: { id: ORG_ID } },
 		);
-		expect(result).toEqual({ customerId: "cus_abc" });
+		expect(result).toEqual({ id: ORG_ID, stripeCustomerId: "cus_abc" });
 	});
 });
 

--- a/src/commands/orgs/set-stripe.ts
+++ b/src/commands/orgs/set-stripe.ts
@@ -4,7 +4,7 @@ import type { OutputFormat } from "../../lib/output.js";
 
 const inputSchema = z.object({
 	orgId: z.string().uuid().describe("Organization ID"),
-	customerId: z.string().min(1).describe("Stripe customer ID (e.g. cus_xxx)"),
+	stripeCustomerId: z.string().min(1).describe("Stripe customer ID (e.g. cus_xxx)"),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -20,7 +20,7 @@ export const orgsSetStripe: ElnoraCommand<Input> = {
 	async execute(input, ctx) {
 		return ctx.client.put(
 			"organization_stripe_customer",
-			{ customerId: input.customerId },
+			{ stripeCustomerId: input.stripeCustomerId },
 			{ pathParams: { id: input.orgId } },
 		);
 	},


### PR DESCRIPTION
## Summary

The `orgs set-stripe` command was sending the Stripe customer ID under the wrong field name in the request payload. The API silently ignored the unknown field, which left the underlying value unset — clearing any previously-stored value rather than updating it.

## Change

- Schema field renamed: `customerId` → `stripeCustomerId` so the auto-derived positional argument label and the wire payload key both match the API contract.
- Wire payload key fixed accordingly.
- Test updated to assert the corrected payload.

**No invocation change for positional callers** — `elnora orgs set-stripe <orgId> <customerId>` works as before. Only the help-text label updates from `<customer-id>` to `<stripe-customer-id>`.

## Companion change

The same fix needs to land in `elnora-mcp-server` (https://github.com/Elnora-AI/elnora-mcp-server/pull/207), since the MCP-parity audit checks both surfaces. **Merge the mcp-server PR first**, then this one's parity check will go green.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test -- orgs` — all tests pass
- [x] Built locally and verified end-to-end against a test environment