### PR TITLE
chore(ci): publish to npm via OIDC trusted publishing on node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
       - name: Sync version from release tag
@@ -113,8 +113,6 @@ jobs:
       - run: pnpm build
       - run: pnpm test
       - run: pnpm publish --access public --no-git-checks --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   smoke-test:
     name: "Smoke Test (${{ matrix.os }})"


### PR DESCRIPTION
Use npm's [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (GitHub Actions OIDC) for `npm publish`, and bump the publish job to Node 24 (npm 11.x — Trusted Publishing requires npm 11.5+).

Trusted Publisher already configured on the npm package side. Other jobs in this workflow are unaffected.