### PR TITLE
fix(cli): doctor accuracy, install-aware updater, actionable network errors

### DIFF
--- a/__tests__/commands/doctor.test.ts
+++ b/__tests__/commands/doctor.test.ts
@@ -63,8 +63,14 @@ function installFetchMock(overrides?: Record<string, { status: number; body?: un
 }
 
 describe("elnora doctor", () => {
+	// A clean, isolated project dir so project-scope settings reads
+	// (process.cwd()/.claude/settings.json) are deterministic across machines.
+	let TEST_PROJECT: string;
+
 	beforeEach(() => {
 		installFetchMock();
+		TEST_PROJECT = mkdtempSync(join(tmpdir(), "elnora-doctor-proj-"));
+		vi.spyOn(process, "cwd").mockReturnValue(TEST_PROJECT);
 	});
 
 	afterEach(() => {
@@ -72,6 +78,11 @@ describe("elnora doctor", () => {
 		try {
 			rmSync(TEST_HOME, { recursive: true, force: true });
 			mkdirSync(TEST_HOME, { recursive: true });
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(TEST_PROJECT, { recursive: true, force: true });
 		} catch {
 			// ignore
 		}
@@ -249,16 +260,54 @@ describe("elnora doctor", () => {
 		}
 	});
 
-	test("summary line reflects pass/fail/warn counts", async () => {
+	test("summary line reflects pass/skip/fail counts", async () => {
 		installFetchMock({ "mcp.elnora.ai": { status: 503 } });
 		const capture = captureStderr();
 		const program = new Command();
 		addDoctorCommand(program);
 		await program.parseAsync(["node", "elnora", "doctor"]);
 		const output = capture.getOutput();
-		// Summary line format: "N/10 checks passed — N failed." or with warning suffix
-		// "N/10 checks passed — N failed (N warning(s))." — auth will also fail in test env.
-		expect(output).toMatch(/\/10 checks passed — \d+ failed/);
+		// New skip-aware summary format: "N passed, N skipped, N failed."
+		expect(output).toMatch(/\d+ passed/);
+		expect(output).toMatch(/\d+ failed/);
+		// Claude Code never launched in this env → those checks skip, not pass.
+		expect(output).toMatch(/\d+ skipped/);
+		capture.restore();
+	});
+
+	// ----- project-scope settings -----
+	test("passes plugin check when enabled at project scope only", async () => {
+		// User scope exists (so Claude Code counts as installed) but does NOT enable
+		// the plugin; the project's .claude/settings.json does.
+		const userClaude = join(TEST_HOME, ".claude");
+		mkdirSync(userClaude, { recursive: true });
+		writeFileSync(join(userClaude, "settings.json"), JSON.stringify({ enabledPlugins: {} }));
+		const projClaude = join(TEST_PROJECT, ".claude");
+		mkdirSync(projClaude, { recursive: true });
+		writeFileSync(
+			join(projClaude, "settings.json"),
+			JSON.stringify({ enabledPlugins: { "elnora@elnora-plugins": true } }),
+		);
+
+		const capture = captureStderr();
+		const program = new Command();
+		addDoctorCommand(program);
+		await program.parseAsync(["node", "elnora", "doctor"]);
+		const output = capture.getOutput();
+		expect(output).toMatch(/✓[^\n]*Plugin enabled.*elnora@elnora-plugins.*project scope/);
+		capture.restore();
+	});
+
+	// ----- skip is not counted as pass -----
+	test("does not report 'All checks passed' when checks were skipped", async () => {
+		// Fresh machine: Claude Code never installed → its 3 checks skip.
+		const capture = captureStderr();
+		const program = new Command();
+		addDoctorCommand(program);
+		await program.parseAsync(["node", "elnora", "doctor"]);
+		const output = capture.getOutput();
+		expect(output).not.toContain("All checks passed");
+		expect(output).toMatch(/3 skipped/);
 		capture.restore();
 	});
 });

--- a/__tests__/commands/update.test.ts
+++ b/__tests__/commands/update.test.ts
@@ -1,0 +1,74 @@
+import { copyFileSync, mkdirSync, readdirSync, renameSync, rmSync } from "node:fs";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Override only the fs calls installWindowsBinary touches; keep everything else
+// real so the rest of the module graph loads normally.
+vi.mock("node:fs", async () => {
+	const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+	return {
+		...actual,
+		mkdirSync: vi.fn(),
+		renameSync: vi.fn(),
+		copyFileSync: vi.fn(),
+		readdirSync: vi.fn(() => []),
+		rmSync: vi.fn(),
+	};
+});
+
+const { installWindowsBinary } = await import("../../src/commands/update.js");
+
+const mkdir = vi.mocked(mkdirSync);
+const rename = vi.mocked(renameSync);
+const copy = vi.mocked(copyFileSync);
+const readdir = vi.mocked(readdirSync);
+const rm = vi.mocked(rmSync);
+
+describe("installWindowsBinary (Windows self-update)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		readdir.mockReturnValue([] as never);
+	});
+
+	test("renames the in-use binary aside, then copies the new one into place", () => {
+		const dest = installWindowsBinary("/tmp/extracted/elnora-win-x64.exe", "/home/x/.elnora/bin");
+
+		expect(mkdir).toHaveBeenCalled();
+		expect(rename).toHaveBeenCalledTimes(1);
+		const [from, to] = rename.mock.calls[0];
+		expect(String(from)).toMatch(/elnora\.exe$/);
+		expect(String(to)).toMatch(/elnora\.exe\.old-\d+$/);
+		// Copy lands at the original destination, only AFTER the rename freed it.
+		expect(copy).toHaveBeenCalledWith("/tmp/extracted/elnora-win-x64.exe", expect.stringMatching(/elnora\.exe$/));
+		expect(dest).toMatch(/elnora\.exe$/);
+	});
+
+	test("tolerates a missing existing binary (ENOENT on rename)", () => {
+		rename.mockImplementationOnce(() => {
+			const e = new Error("not found") as NodeJS.ErrnoException;
+			e.code = "ENOENT";
+			throw e;
+		});
+		expect(() => installWindowsBinary("src", "dir")).not.toThrow();
+		expect(copy).toHaveBeenCalled();
+	});
+
+	test("propagates a non-ENOENT rename failure instead of swallowing it", () => {
+		rename.mockImplementationOnce(() => {
+			const e = new Error("device busy") as NodeJS.ErrnoException;
+			e.code = "EBUSY";
+			throw e;
+		});
+		expect(() => installWindowsBinary("src", "dir")).toThrow(/busy/);
+		expect(copy).not.toHaveBeenCalled();
+	});
+
+	test("sweeps stale .old-* binaries from previous updates, leaving other files", () => {
+		readdir.mockReturnValue(["elnora.exe", "elnora.exe.old-111", "elnora.exe.old-222", "keep.txt"] as never);
+		installWindowsBinary("src", "dir");
+		const removed = rm.mock.calls.map((c) => String(c[0]));
+		expect(removed.some((p) => p.includes("elnora.exe.old-111"))).toBe(true);
+		expect(removed.some((p) => p.includes("elnora.exe.old-222"))).toBe(true);
+		expect(removed.some((p) => p.endsWith("keep.txt"))).toBe(false);
+		expect(removed.some((p) => p.endsWith("elnora.exe"))).toBe(false);
+	});
+});

--- a/__tests__/lib/client.test.ts
+++ b/__tests__/lib/client.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from "vitest";
-import { validateApiUrl, validateUploadUrl } from "../../src/lib/client.js";
-import { ElnoraError, ValidationError } from "../../src/lib/errors.js";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { ElnoraApiClient, validateApiUrl, validateUploadUrl } from "../../src/lib/client.js";
+import { ElnoraError, NetworkError, ValidationError } from "../../src/lib/errors.js";
 
 describe("SSRF protection — validateApiUrl", () => {
 	test("accepts platform.elnora.ai", () => {
@@ -65,5 +65,50 @@ describe("Upload URL validation — validateUploadUrl", () => {
 	test("allows userinfo in query string (not path)", () => {
 		// @ in query string should be fine — only path/authority matters
 		expect(() => validateUploadUrl("https://bucket.s3.amazonaws.com/key?email=user@example.com")).not.toThrow();
+	});
+});
+
+describe("Network error mapping", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// A custom (non-production) baseUrl bypasses the SSRF allowlist so we can
+	// drive a real fetch rejection without hitting the network.
+	const client = new ElnoraApiClient("elnora_live_test_key", { baseUrl: "https://api.example.test/api/v1" });
+
+	test("DNS failure surfaces host + underlying code + doctor pointer", async () => {
+		globalThis.fetch = vi.fn(async () => {
+			throw new TypeError("fetch failed", { cause: { code: "ENOTFOUND" } });
+		}) as typeof fetch;
+
+		await expect(client.get("/projects")).rejects.toMatchObject({
+			code: "NETWORK_ERROR",
+		});
+		try {
+			await client.get("/projects");
+		} catch (e) {
+			const err = e as NetworkError;
+			expect(err).toBeInstanceOf(NetworkError);
+			expect(err.message).toContain("api.example.test");
+			expect(err.message).toContain("ENOTFOUND");
+			expect(err.suggestion).toContain("elnora doctor");
+		}
+	});
+
+	test("connection refused names the host", async () => {
+		globalThis.fetch = vi.fn(async () => {
+			throw new TypeError("fetch failed", { cause: { code: "ECONNREFUSED" } });
+		}) as typeof fetch;
+
+		try {
+			await client.get("/projects");
+			throw new Error("expected NetworkError");
+		} catch (e) {
+			const err = e as NetworkError;
+			expect(err).toBeInstanceOf(NetworkError);
+			expect(err.message).toContain("ECONNREFUSED");
+			expect(err.host).toBe("api.example.test");
+		}
 	});
 });

--- a/__tests__/lib/errors.test.ts
+++ b/__tests__/lib/errors.test.ts
@@ -5,6 +5,7 @@ import {
 	EXIT_CODES,
 	formatErrorPayload,
 	getExitCode,
+	NetworkError,
 	NotFoundError,
 	RateLimitError,
 	ServerError,
@@ -65,6 +66,23 @@ describe("Error hierarchy", () => {
 		const err = new ServerError();
 		expect(err.code).toBe("SERVER_ERROR");
 		expect(EXIT_CODES.get(ServerError)).toBe(6);
+	});
+
+	test("NetworkError includes host, cause, and a doctor pointer", () => {
+		const err = new NetworkError("platform.elnora.ai", "ENOTFOUND");
+		expect(err.code).toBe("NETWORK_ERROR");
+		expect(err.message).toContain("platform.elnora.ai");
+		expect(err.message).toContain("ENOTFOUND");
+		expect(err.suggestion).toContain("elnora doctor");
+		expect(err.suggestion).toContain("platform.elnora.ai");
+		expect(err.host).toBe("platform.elnora.ai");
+	});
+
+	test("NetworkError without a host still points at doctor", () => {
+		const err = new NetworkError();
+		expect(err.code).toBe("NETWORK_ERROR");
+		expect(err.suggestion).toContain("elnora doctor");
+		expect(err.host).toBeUndefined();
 	});
 });
 

--- a/__tests__/lib/update-check.test.ts
+++ b/__tests__/lib/update-check.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// Force a known install method so we can assert the routed command.
+vi.mock("../../src/lib/install-method.js", () => ({
+	detectInstallMethod: vi.fn(() => "binary"),
+	getUpdateInstruction: vi.fn((m: string) =>
+		m === "npm"
+			? "npm install -g @elnora-ai/cli@latest"
+			: m === "homebrew"
+				? "brew upgrade elnora"
+				: "elnora update --install",
+	),
+}));
+
+const { showUpdateNotice } = await import("../../src/lib/update-check.js");
+
+describe("showUpdateNotice", () => {
+	let writes: string[];
+	let writeSpy: ReturnType<typeof vi.spyOn>;
+	const origIsTTY = process.stderr.isTTY;
+
+	beforeEach(() => {
+		writes = [];
+		Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+		writeSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+			writes.push(String(chunk));
+			return true;
+		});
+	});
+
+	afterEach(() => {
+		writeSpy.mockRestore();
+		Object.defineProperty(process.stderr, "isTTY", { value: origIsTTY, configurable: true });
+	});
+
+	test("advertises the install-method-specific command, not bare 'elnora update'", () => {
+		showUpdateNotice("9.9.9");
+		const out = writes.join("");
+		expect(out).toContain("Update available");
+		expect(out).toContain("Run: elnora update --install");
+		// Regression guard: the original bug advertised the check-only command.
+		expect(out).not.toMatch(/Run: elnora update\n/);
+	});
+
+	test("writes nothing when stderr is not a TTY", () => {
+		Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
+		showUpdateNotice("9.9.9");
+		expect(writes.join("")).toBe("");
+	});
+});

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -119,36 +119,63 @@ function checkPathConfigured(): CheckResult {
 	};
 }
 
+/** The enabledPlugins map from a settings.json, plus a parse-error note if unreadable. */
+interface SettingsRead {
+	enabledPlugins: Record<string, boolean>;
+	unreadable?: string;
+}
+
+/** Read enabledPlugins from a settings.json. Returns null when the file is absent. */
+function readEnabledPlugins(file: string): SettingsRead | null {
+	if (!existsSync(file)) return null;
+	try {
+		const settings = JSON.parse(readFileSync(file, "utf-8")) as Record<string, unknown>;
+		const raw = settings.enabledPlugins;
+		// Must be a plain object — reject arrays and non-objects to prevent confusing
+		// "not found" failures when settings.json is malformed.
+		const enabledPlugins =
+			typeof raw === "object" && raw !== null && !Array.isArray(raw) ? (raw as Record<string, boolean>) : {};
+		return { enabledPlugins };
+	} catch (e) {
+		return { enabledPlugins: {}, unreadable: e instanceof Error ? e.message : "parse error" };
+	}
+}
+
 function checkClaudePlugin(): CheckResult {
 	if (!existsSync(CLAUDE_DIR)) {
 		return { status: "skip", msg: "Plugin enabled         (Claude Code not installed)" };
 	}
-	if (!existsSync(CLAUDE_SETTINGS_FILE)) {
+	// Claude Code merges user-level and project-level settings at runtime (project
+	// takes precedence). Read both, or the check reports a false negative inside a
+	// project that enables the plugin at project scope.
+	const projectSettingsFile = join(process.cwd(), ".claude", "settings.json");
+	const user = readEnabledPlugins(CLAUDE_SETTINGS_FILE);
+	const project = readEnabledPlugins(projectSettingsFile);
+
+	if (!user && !project) {
 		return { status: "fail", msg: "Plugin enabled         settings.json not found — run 'elnora setup claude'" };
 	}
-	let settings: Record<string, unknown>;
-	try {
-		settings = JSON.parse(readFileSync(CLAUDE_SETTINGS_FILE, "utf-8")) as Record<string, unknown>;
-	} catch (e) {
-		return {
-			status: "fail",
-			msg: `Plugin enabled         settings.json unreadable (${e instanceof Error ? e.message : "parse error"})`,
-		};
+	// Only surface "unreadable" when there's no usable settings at the other scope.
+	if (user?.unreadable && !project?.enabledPlugins[PLUGIN_ID]) {
+		return { status: "fail", msg: `Plugin enabled         settings.json unreadable (${user.unreadable})` };
 	}
-	// Must be a plain object — reject arrays and non-objects to prevent confusing "not found"
-	// failures when settings.json is malformed (e.g. enabledPlugins is accidentally an array).
-	const raw = settings.enabledPlugins;
-	const enabledPlugins: Record<string, boolean> =
-		typeof raw === "object" && raw !== null && !Array.isArray(raw) ? (raw as Record<string, boolean>) : {};
-	const isEnabled = enabledPlugins[PLUGIN_ID] === true;
-	const legacyKeys = Object.keys(enabledPlugins).filter((k) => k.startsWith("elnora@") && k !== PLUGIN_ID);
+
+	const userEnabled = user?.enabledPlugins[PLUGIN_ID] === true;
+	const projectEnabled = project?.enabledPlugins[PLUGIN_ID] === true;
+	const isEnabled = userEnabled || projectEnabled;
+	const scope = projectEnabled ? (userEnabled ? "user + project" : "project") : "user";
+
+	const legacyKeys = [
+		...new Set([...Object.keys(user?.enabledPlugins ?? {}), ...Object.keys(project?.enabledPlugins ?? {})]),
+	].filter((k) => k.startsWith("elnora@") && k !== PLUGIN_ID);
+
 	if (isEnabled && legacyKeys.length === 0) {
-		return { status: "pass", msg: `Plugin enabled         ${PLUGIN_ID}` };
+		return { status: "pass", msg: `Plugin enabled         ${PLUGIN_ID} (${scope} scope)` };
 	}
 	if (isEnabled && legacyKeys.length > 0) {
 		return {
 			status: "warn",
-			msg: `Plugin enabled         ${PLUGIN_ID} — but stale legacy entries also present: ${legacyKeys.join(", ")}`,
+			msg: `Plugin enabled         ${PLUGIN_ID} (${scope} scope) — but stale legacy entries also present: ${legacyKeys.join(", ")}`,
 		};
 	}
 	if (legacyKeys.length > 0) {
@@ -160,15 +187,57 @@ function checkClaudePlugin(): CheckResult {
 	return { status: "fail", msg: "Plugin enabled         not found — run 'elnora setup claude'" };
 }
 
+/**
+ * Whether the elnora marketplace has been *registered* (via `elnora setup
+ * claude`) — distinct from whether Claude Code has *cloned* it yet. Registration
+ * shows up as an enabledPlugins entry or extraKnownMarketplaces in user/project
+ * settings, or in Claude Code's known_marketplaces.json once setup has run.
+ */
+function isMarketplaceRegistered(): boolean {
+	for (const file of [CLAUDE_SETTINGS_FILE, join(process.cwd(), ".claude", "settings.json")]) {
+		if (!existsSync(file)) continue;
+		try {
+			const settings = JSON.parse(readFileSync(file, "utf-8")) as Record<string, unknown>;
+			const enabled = settings.enabledPlugins;
+			if (typeof enabled === "object" && enabled !== null && (enabled as Record<string, boolean>)[PLUGIN_ID] === true) {
+				return true;
+			}
+			const extra = settings.extraKnownMarketplaces;
+			if (extra != null && JSON.stringify(extra).includes(MARKETPLACE_NAME)) return true;
+		} catch {
+			/* unreadable settings — ignore, fall through */
+		}
+	}
+	const knownMarketplaces = join(CLAUDE_DIR, "plugins", "known_marketplaces.json");
+	if (existsSync(knownMarketplaces)) {
+		try {
+			if (JSON.stringify(JSON.parse(readFileSync(knownMarketplaces, "utf-8"))).includes(MARKETPLACE_NAME)) {
+				return true;
+			}
+		} catch {
+			/* ignore */
+		}
+	}
+	return false;
+}
+
 function checkSkillsInstalled(): CheckResult {
 	if (!existsSync(CLAUDE_DIR)) {
 		return { status: "skip", msg: "Skills installed       (Claude Code not installed)" };
 	}
 	const skillsDir = join(CLAUDE_DIR, "plugins", "marketplaces", MARKETPLACE_NAME, "elnora", "skills");
 	if (!existsSync(skillsDir)) {
+		// Distinguish "registered but pre-first-launch" (expected, self-resolving)
+		// from "never set up" (actionable) so customers stop chasing a non-problem.
+		if (isMarketplaceRegistered()) {
+			return {
+				status: "warn",
+				msg: "Skills installed       registered but not cloned yet — open this folder in Claude Code once to clone",
+			};
+		}
 		return {
 			status: "warn",
-			msg: "Skills installed       marketplace not cloned yet — restart Claude Code to trigger clone",
+			msg: "Skills installed       marketplace not registered — run 'elnora setup claude'",
 		};
 	}
 	const found = EXPECTED_SKILLS.filter((s) => existsSync(join(skillsDir, s, "SKILL.md")));
@@ -269,16 +338,30 @@ export function addDoctorCommand(program: Command): void {
 			console.error(`\nElnora CLI v${VERSION}\n`);
 
 			let passed = 0;
+			let skipped = 0;
 			let failed = 0;
 			let warnings = 0;
-			let total = 0;
 			const tally = (r: CheckResult) => {
-				total++;
-				if (r.status === "pass" || r.status === "skip") passed++;
-				else if (r.status === "warn") {
-					passed++;
-					warnings++;
-				} else failed++;
+				switch (r.status) {
+					case "pass":
+						passed++;
+						break;
+					case "warn":
+						// A warning is non-fatal, so it still counts toward "passed",
+						// but is surfaced separately in the summary.
+						passed++;
+						warnings++;
+						break;
+					case "skip":
+						// `skip` means "not verified" (e.g. Claude Code never launched).
+						// It must NOT count as a pass, or fresh machines falsely report
+						// a clean bill of health.
+						skipped++;
+						break;
+					case "fail":
+						failed++;
+						break;
+				}
 			};
 
 			// ------ CLI section ------
@@ -320,14 +403,18 @@ export function addDoctorCommand(program: Command): void {
 			console.error("");
 
 			// ------ Summary ------
-			if (failed === 0 && warnings === 0) {
+			// Report passed / skipped / warnings / failed separately so the score
+			// reflects what was actually verified and stays consistent across
+			// platforms (skips no longer masquerade as passes).
+			if (failed === 0 && warnings === 0 && skipped === 0) {
 				console.error("All checks passed.");
-			} else if (failed === 0) {
-				console.error(`${passed}/${total} checks passed (${warnings} warning${warnings === 1 ? "" : "s"}).`);
 			} else {
-				const warnSuffix = warnings > 0 ? ` (${warnings} warning${warnings === 1 ? "" : "s"})` : "";
-				console.error(`${passed}/${total} checks passed — ${failed} failed${warnSuffix}.`);
-				if (!existsSync(PROFILES_FILE)) console.error("\nRun: elnora auth login");
+				const parts = [`${passed} passed`];
+				if (skipped > 0) parts.push(`${skipped} skipped`);
+				if (warnings > 0) parts.push(`${warnings} warning${warnings === 1 ? "" : "s"}`);
+				if (failed > 0) parts.push(`${failed} failed`);
+				console.error(`${parts.join(", ")}.`);
+				if (failed > 0 && !existsSync(PROFILES_FILE)) console.error("\nRun: elnora auth login");
 			}
 		});
 }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,6 +1,15 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, copyFileSync, createWriteStream, mkdirSync, readFileSync, rmSync } from "node:fs";
+import {
+	chmodSync,
+	copyFileSync,
+	createWriteStream,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable } from "node:stream";
@@ -41,6 +50,43 @@ async function downloadToFile(url: string, dest: string): Promise<void> {
 	if (!res.ok || !res.body) throw new Error(`HTTP ${res.status}`);
 	const nodeStream = Readable.fromWeb(res.body as import("stream/web").ReadableStream);
 	await pipeline(nodeStream, createWriteStream(dest));
+}
+
+/**
+ * Place a freshly-downloaded `elnora.exe` into `installDir` on Windows.
+ *
+ * Windows refuses to overwrite a running PE executable (the loader holds an
+ * exclusive lock), but it *does* allow renaming it. Since `elnora update
+ * --install` runs from inside the very binary it's replacing, we move the
+ * in-use binary aside first, then drop the new one into place — the canonical
+ * Windows self-update pattern. The renamed `.old-*` file is still locked while
+ * the current process runs; it (and any from earlier updates) is swept on a
+ * later invocation once the OS frees the lock.
+ *
+ * Exported for testing. Returns the destination path.
+ */
+export function installWindowsBinary(srcPath: string, installDir: string): string {
+	mkdirSync(installDir, { recursive: true });
+	const dest = join(installDir, "elnora.exe");
+	try {
+		renameSync(dest, `${dest}.old-${Date.now()}`);
+	} catch (e) {
+		// ENOENT just means there's nothing to move (first install / external
+		// removal). Anything else is a real failure worth surfacing.
+		if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+	}
+	copyFileSync(srcPath, dest);
+	// Best-effort sweep of `.old-*` binaries left by previous updates.
+	for (const name of readdirSync(installDir)) {
+		if (name.startsWith("elnora.exe.old-")) {
+			try {
+				rmSync(join(installDir, name), { force: true });
+			} catch {
+				/* still locked / in use — will be swept on a later run */
+			}
+		}
+	}
+	return dest;
 }
 
 async function installBinaryUpdate(latest: string): Promise<void> {
@@ -98,8 +144,7 @@ async function installBinaryUpdate(latest: string): Promise<void> {
 				`Expand-Archive -Path '${archivePath}' -DestinationPath '${extractDir}' -Force`,
 			]);
 			const installDir = join(process.env.USERPROFILE ?? process.env.HOME ?? "", ".elnora", "bin");
-			mkdirSync(installDir, { recursive: true });
-			copyFileSync(join(extractDir, target), join(installDir, "elnora.exe"));
+			installWindowsBinary(join(extractDir, target), installDir);
 		} else {
 			execFileSync("tar", ["-xzf", archivePath, "-C", tmp]);
 			const installDir = process.env.ELNORA_INSTALL_DIR ?? join(process.env.HOME ?? "", ".local", "bin");
@@ -188,8 +233,13 @@ export function addUpdateCommand(program: Command): void {
 			// Binary self-replace
 			try {
 				await installBinaryUpdate(latest);
-			} catch {
-				console.error("Update failed. Try manually:");
+			} catch (err) {
+				// Bind the error — an empty catch turned every failure (network,
+				// checksum, file-locked) into the same opaque message, leaving users
+				// and bug reports with no idea what actually broke.
+				const reason = err instanceof Error ? err.message : String(err);
+				console.error(`Update failed: ${reason}`);
+				console.error("Try manually:");
 				console.error(
 					process.platform === "win32"
 						? "  irm https://cli.elnora.ai/install.ps1 | iex"

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -15,6 +15,7 @@ import { BASE_URL, buildUrl, DEFAULT_HEADERS, ENDPOINTS, PRODUCTION_BASE_URL, VE
 import {
 	AuthError,
 	ElnoraError,
+	NetworkError,
 	NotFoundError,
 	RateLimitError,
 	ServerError,
@@ -253,16 +254,25 @@ export class ElnoraApiClient {
 				});
 			} catch (err) {
 				if (err instanceof ElnoraError) throw err;
-				if (err instanceof DOMException && err.name === "TimeoutError") {
-					throw new ElnoraError("Request timed out", {
-						code: "TIMEOUT",
-						suggestion: "Check your internet connection and try again.",
-					});
+				// The actual host we failed to reach — ground truth for the error message.
+				let host: string | undefined;
+				try {
+					host = new URL(url).hostname;
+				} catch {
+					host = undefined;
 				}
-				throw new ElnoraError(`Network error: ${scrub(String(err))}`, {
-					code: "NETWORK_ERROR",
-					suggestion: "Check your internet connection and try again.",
-				});
+				if (err instanceof DOMException && err.name === "TimeoutError") {
+					throw new NetworkError(host, `timed out after ${this.timeout}ms`);
+				}
+				// Node wraps the underlying socket failure in `err.cause` with a `.code`
+				// such as ENOTFOUND (DNS), ECONNREFUSED (connection refused), ECONNRESET.
+				const causeCode =
+					err instanceof Error && err.cause && typeof err.cause === "object" && "code" in err.cause
+						? String((err.cause as { code?: unknown }).code)
+						: err instanceof Error
+							? err.message
+							: String(err);
+				throw new NetworkError(host, scrub(causeCode));
 			}
 		}
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -77,6 +77,31 @@ export class ServerError extends ElnoraError {
 	}
 }
 
+/**
+ * Network-layer failure (DNS resolution, connection refused, timeout, etc.).
+ *
+ * Unlike a bare `fetch failed`, this names the actual host the CLI tried to
+ * reach and the underlying cause, and points the user at `elnora doctor` for
+ * connectivity diagnostics — so the next agent or human sees ground truth in
+ * the error itself. Mirrors the AuthError pattern above.
+ */
+export class NetworkError extends ElnoraError {
+	readonly host: string | undefined;
+
+	constructor(host?: string, cause?: string) {
+		const target = host ? ` reaching ${host}` : "";
+		const reason = cause ? ` (${cause})` : "";
+		super(`Network error${target}${reason}`, {
+			code: "NETWORK_ERROR",
+			suggestion: host
+				? `Run 'elnora doctor' to diagnose connectivity, then confirm ${host} is reachable from this machine.`
+				: "Run 'elnora doctor' to diagnose connectivity.",
+		});
+		this.name = "NetworkError";
+		this.host = host;
+	}
+}
+
 /** Distinct exit codes per error type — matches Python CLI exactly. */
 export const EXIT_CODES = new Map<new (...args: never[]) => ElnoraError, number>([
 	[ValidationError, 2],

--- a/src/lib/update-check.ts
+++ b/src/lib/update-check.ts
@@ -11,6 +11,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import pc from "picocolors";
 import { VERSION } from "./config.js";
+import { detectInstallMethod, getUpdateInstruction } from "./install-method.js";
 import { isColorEnabled } from "./tty.js";
 
 const NPM_REGISTRY_URL = "https://registry.npmjs.org/@elnora-ai/cli/latest";
@@ -50,14 +51,18 @@ function writeCache(entry: CacheEntry): void {
 	}
 }
 
-function showUpdateNotice(latest: string): void {
+/** Exported for testing. Writes the update banner with the install-aware command. */
+export function showUpdateNotice(latest: string): void {
 	// Only show in TTY
 	if (!process.stderr.isTTY) return;
 
+	// Advertise the command that actually installs the update, routed by how the
+	// CLI was installed (npm / Homebrew / binary). Previously this always said
+	// "elnora update", which only *checks* — the wrong command for every channel.
+	const command = getUpdateInstruction(detectInstallMethod());
 	const color = isColorEnabled();
-	const msg = color
-		? `\n${pc.yellow(`Update available: v${VERSION} → v${latest}`)}\nRun: elnora update\n`
-		: `\nUpdate available: v${VERSION} → v${latest}\nRun: elnora update\n`;
+	const head = `Update available: v${VERSION} → v${latest}`;
+	const msg = color ? `\n${pc.yellow(head)}\nRun: ${command}\n` : `\n${head}\nRun: ${command}\n`;
 	process.stderr.write(msg);
 }
 


### PR DESCRIPTION
## Summary

Three CLI reliability fixes:

- **`elnora doctor` accuracy:** reads project-scope `.claude/settings.json` in addition to user scope (and shows which scope enabled the plugin), so it no longer reports a false negative inside a project that enables the plugin. Skipped checks are no longer counted as passes — the summary now reports passed and skipped separately. A registered-but-not-yet-cloned marketplace is distinguished from one that was never set up.
- **`elnora update`:** the "update available" notice now suggests the command that actually installs the update (based on how the CLI was installed) instead of the check-only `elnora update`. Install failures now report the underlying reason rather than a single opaque message. Windows self-update no longer fails to overwrite the running executable — it moves the in-use binary aside before installing the new one, and cleans up leftovers on later runs.
- **Network errors:** connection failures now name the host and the underlying cause (DNS failure, connection refused, timeout) and suggest running `elnora doctor`, instead of a generic `fetch failed`.

## Testing

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] `pnpm build` succeeds
- [x] Tested locally with `node dist/cli.js`

## Linear Issue

Closes ELN-748
Closes ELN-661
Closes ELN-777

🤖 Generated with [Claude Code](https://claude.com/claude-code)
