### PR TITLE
feat(cli): TTY-aware output, config show, secure/stdin input, doctor & banner DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,25 @@ API keys are stored in `~/.elnora/profiles.toml` with secure file permissions (0
 
 ## Output Formats
 
+By default the CLI prints a **human-readable table** in an interactive terminal and
+**JSON when the output is piped or redirected** — so `elnora ... | jq` and scripts/agents
+keep getting JSON automatically, with no flag required.
+
 ```bash
-elnora projects list                    # JSON (default)
-elnora projects list --compact          # Compact JSON
+elnora projects list                    # table in a terminal, JSON when piped
+elnora projects list | jq               # JSON (piped → machine format)
+elnora projects list --json             # force JSON, even in a terminal
+elnora projects list --output table     # force the human table
+elnora projects list --md               # Markdown (great for agents/chat/docs)
 elnora projects list --output csv       # CSV
-elnora projects list --fields id,name   # Field filtering
-elnora projects list --json             # Force JSON (even in TTY)
+elnora projects list --compact          # compact (single-line) JSON
+elnora projects list --fields id,name   # field filtering (works with any format)
 ```
+
+Other global flags: `--quiet` (suppress spinners and update notices), `--no-color`
+(disable colored output; `NO_COLOR` is also honored).
+
+Run `elnora config show` to print the resolved endpoints and active profile.
 
 ## Documentation
 

--- a/__tests__/adapters/cli.test.ts
+++ b/__tests__/adapters/cli.test.ts
@@ -1,3 +1,4 @@
+import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import { buildProgram, zodToCommanderOptions } from "../../src/adapters/cli.js";
@@ -265,5 +266,130 @@ describe("buildProgram output formatting", () => {
 		const parsed = JSON.parse(out);
 		expect(parsed.items[0]).toHaveProperty("id");
 		expect(parsed.items[0]).not.toHaveProperty("name");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildProgram — stdin "-" substitution
+// ---------------------------------------------------------------------------
+
+const sendCmd: ElnoraCommand = {
+	name: "demo.send",
+	group: "demo",
+	description: "Send a demo message",
+	stdinField: "message",
+	inputSchema: z.object({ message: z.string().min(1) }),
+	outputSchema: z.any(),
+	async execute(input: unknown) {
+		return { received: (input as { message: string }).message };
+	},
+	formatOutput(output: unknown) {
+		return JSON.stringify(output);
+	},
+};
+
+describe("buildProgram stdin '-' substitution", () => {
+	const realStdin = process.stdin;
+	let origExit: number | string | undefined;
+
+	beforeEach(() => {
+		origExit = process.exitCode;
+		Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+		Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+		Object.defineProperty(process, "stdin", { value: realStdin, configurable: true });
+		process.exitCode = origExit;
+	});
+
+	function fakeStdin(content: string | null, isTTY: boolean) {
+		const fake = new PassThrough() as PassThrough & { isTTY?: boolean };
+		fake.isTTY = isTTY;
+		if (content !== null) {
+			fake.write(content);
+			fake.end();
+		}
+		Object.defineProperty(process, "stdin", { value: fake, configurable: true });
+	}
+
+	async function runSend(cmd: ElnoraCommand, args: string[]) {
+		const program = buildProgram(makeRegistry(cmd));
+		await program.parseAsync(["node", "elnora", "demo", "send", ...args]);
+	}
+
+	test("reads the field from piped stdin when value is '-'", async () => {
+		fakeStdin("hello world\n", false);
+		const cap = spyStreams();
+		await runSend(sendCmd, ["--message", "-"]);
+		const out = cap.out();
+		cap.restore();
+		expect(JSON.parse(out).received).toBe("hello world");
+	});
+
+	test("keeps internal newlines, strips one trailing newline", async () => {
+		fakeStdin("line1\nline2\n", false);
+		const cap = spyStreams();
+		await runSend(sendCmd, ["--message", "-"]);
+		const out = cap.out();
+		cap.restore();
+		expect(JSON.parse(out).received).toBe("line1\nline2");
+	});
+
+	test("'-' with stdin a TTY → ValidationError, exit 2 (no hang)", async () => {
+		fakeStdin(null, true);
+		const cap = spyStreams();
+		await runSend(sendCmd, ["--message", "-"]);
+		const err = cap.err();
+		cap.restore();
+		expect(JSON.parse(err).code).toBe("VALIDATION_ERROR");
+		expect(process.exitCode).toBe(2);
+	});
+
+	test("empty pipe → Zod min(1) ValidationError", async () => {
+		fakeStdin("", false);
+		const cap = spyStreams();
+		await runSend(sendCmd, ["--message", "-"]);
+		const err = cap.err();
+		cap.restore();
+		expect(JSON.parse(err).code).toBe("VALIDATION_ERROR");
+	});
+
+	test("a non-'-' value is used verbatim (stdin not read)", async () => {
+		fakeStdin("SHOULD NOT BE READ", false);
+		const cap = spyStreams();
+		await runSend(sendCmd, ["--message", "literal"]);
+		const out = cap.out();
+		cap.restore();
+		expect(JSON.parse(out).received).toBe("literal");
+	});
+
+	test("a command WITHOUT stdinField treats '-' as a literal value", async () => {
+		const noStdin: ElnoraCommand = { ...sendCmd, stdinField: undefined };
+		fakeStdin("SHOULD NOT BE READ", false);
+		const cap = spyStreams();
+		await runSend(noStdin, ["--message", "-"]);
+		const out = cap.out();
+		cap.restore();
+		expect(JSON.parse(out).received).toBe("-");
+	});
+});
+
+// Every declared stdinField must reference a real field in its command's schema.
+describe("stdinField validity", () => {
+	test("each command's stdinField exists in its input schema", async () => {
+		const { buildRegistry } = await import("../../src/core/build-registry.js");
+		const registry = buildRegistry();
+		for (const cmd of registry.all()) {
+			if (!cmd.stdinField) continue;
+			const fields = zodToCommanderOptions(cmd.inputSchema).map((o) => {
+				const token = o.flags.trim().split(/\s+/)[0];
+				return token
+					.replace(/^--/, "")
+					.replace(/[<>[\]]/g, "")
+					.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+			});
+			expect(fields).toContain(cmd.stdinField);
+		}
 	});
 });

--- a/__tests__/adapters/cli.test.ts
+++ b/__tests__/adapters/cli.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { z } from "zod";
-import { zodToCommanderOptions } from "../../src/adapters/cli.js";
+import { buildProgram, zodToCommanderOptions } from "../../src/adapters/cli.js";
+import type { ElnoraCommand } from "../../src/core/command.js";
+import type { CommandRegistry } from "../../src/core/registry.js";
+
+// The adapter builds a client via ElnoraApiClient.fromEnv for non-auth commands;
+// stub it so these tests don't need a real profile/network.
+vi.mock("../../src/lib/client.js", () => {
+	const Client = vi.fn();
+	(Client as unknown as { fromEnv: () => unknown }).fromEnv = vi.fn(() => ({}));
+	return { ElnoraApiClient: Client };
+});
 
 describe("zodToCommanderOptions", () => {
 	test("converts required string to --flag <value>", () => {
@@ -91,5 +101,169 @@ describe("zodToCommanderOptions", () => {
 		expect(options[1].flags).toContain("--name");
 		expect(options[2].flags).toContain("--description");
 		expect(options[3].flags).toContain("--page");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildProgram — output format resolution (TTY-aware default, --json/--md/etc.)
+// ---------------------------------------------------------------------------
+
+const demoCmd: ElnoraCommand = {
+	name: "demo.list",
+	group: "demo",
+	description: "List demo records",
+	inputSchema: z.object({}),
+	outputSchema: z.any(),
+	async execute() {
+		return { items: [{ id: "1", name: "Alpha" }], totalCount: 1 };
+	},
+	formatOutput(output: unknown) {
+		return JSON.stringify(output, null, 2);
+	},
+};
+
+function makeRegistry(cmd: ElnoraCommand): CommandRegistry {
+	return {
+		groups: () => [cmd.group],
+		byGroup: () => [cmd],
+		all: () => [cmd],
+	} as unknown as CommandRegistry;
+}
+
+function spyStreams() {
+	const out: string[] = [];
+	const err: string[] = [];
+	const o = vi.spyOn(process.stdout, "write").mockImplementation((c: unknown) => {
+		out.push(String(c));
+		return true;
+	});
+	const e = vi.spyOn(process.stderr, "write").mockImplementation((c: unknown) => {
+		err.push(String(c));
+		return true;
+	});
+	return {
+		out: () => out.join(""),
+		err: () => err.join(""),
+		restore: () => {
+			o.mockRestore();
+			e.mockRestore();
+		},
+	};
+}
+
+function setTTY(stdout: boolean, stderr = stdout) {
+	Object.defineProperty(process.stdout, "isTTY", { value: stdout, configurable: true });
+	Object.defineProperty(process.stderr, "isTTY", { value: stderr, configurable: true });
+}
+
+describe("buildProgram output formatting", () => {
+	let origOutTTY: boolean | undefined;
+	let origErrTTY: boolean | undefined;
+	let origExit: number | string | undefined;
+
+	beforeEach(() => {
+		origOutTTY = process.stdout.isTTY;
+		origErrTTY = process.stderr.isTTY;
+		origExit = process.exitCode;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		Object.defineProperty(process.stdout, "isTTY", { value: origOutTTY, configurable: true });
+		Object.defineProperty(process.stderr, "isTTY", { value: origErrTTY, configurable: true });
+		process.exitCode = origExit;
+	});
+
+	async function run(args: string[]) {
+		const program = buildProgram(makeRegistry(demoCmd));
+		await program.parseAsync(["node", "elnora", ...args]);
+	}
+
+	test("non-TTY default → JSON (pipes and agents unaffected)", async () => {
+		setTTY(false);
+		const cap = spyStreams();
+		await run(["demo", "list"]);
+		const out = cap.out();
+		cap.restore();
+		expect(JSON.parse(out).items[0].name).toBe("Alpha");
+	});
+
+	test("TTY default → human table, not JSON", async () => {
+		setTTY(true);
+		const cap = spyStreams();
+		await run(["demo", "list"]);
+		const out = cap.out();
+		cap.restore();
+		expect(out).toContain("id");
+		expect(out).toContain("Alpha");
+		expect(() => JSON.parse(out.trim())).toThrow();
+	});
+
+	test("--json forces JSON even on a TTY", async () => {
+		setTTY(true);
+		const cap = spyStreams();
+		await run(["--json", "demo", "list"]);
+		const out = cap.out();
+		cap.restore();
+		expect(JSON.parse(out).totalCount).toBe(1);
+	});
+
+	test("--compact → single-line JSON", async () => {
+		setTTY(true);
+		const cap = spyStreams();
+		await run(["--compact", "demo", "list"]);
+		const out = cap.out().trim();
+		cap.restore();
+		expect(out).not.toContain("\n");
+		expect(JSON.parse(out).totalCount).toBe(1);
+	});
+
+	test("--md → markdown table even when piped", async () => {
+		setTTY(false);
+		const cap = spyStreams();
+		await run(["--md", "demo", "list"]);
+		const out = cap.out();
+		cap.restore();
+		expect(out).toContain("| id | name |");
+	});
+
+	test("--output markdown → markdown table", async () => {
+		setTTY(false);
+		const cap = spyStreams();
+		await run(["--output", "markdown", "demo", "list"]);
+		const out = cap.out();
+		cap.restore();
+		expect(out).toContain("| id | name |");
+	});
+
+	test("unknown --output value → ValidationError, exit 2", async () => {
+		setTTY(false);
+		const cap = spyStreams();
+		await run(["--output", "yaml", "demo", "list"]);
+		const err = cap.err();
+		cap.restore();
+		expect(JSON.parse(err).code).toBe("VALIDATION_ERROR");
+		expect(process.exitCode).toBe(2);
+	});
+
+	test("--output csv routes through the generic renderer", async () => {
+		setTTY(true);
+		const cap = spyStreams();
+		await run(["--output", "csv", "demo", "list"]);
+		const out = cap.out();
+		cap.restore();
+		expect(out).toContain("id,name");
+		expect(out).toContain("1,Alpha");
+	});
+
+	test("--fields filters columns through the adapter", async () => {
+		setTTY(false);
+		const cap = spyStreams();
+		await run(["--fields", "id", "demo", "list"]);
+		const out = cap.out();
+		cap.restore();
+		const parsed = JSON.parse(out);
+		expect(parsed.items[0]).toHaveProperty("id");
+		expect(parsed.items[0]).not.toHaveProperty("name");
 	});
 });

--- a/__tests__/commands/auth/auth.test.ts
+++ b/__tests__/commands/auth/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { registerAuthCommands } from "../../../src/commands/auth/index.js";
 import { authLogin } from "../../../src/commands/auth/login.js";
 import { authLogout } from "../../../src/commands/auth/logout.js";
@@ -36,6 +36,11 @@ vi.mock("../../../src/lib/client.js", () => {
 	return { ElnoraApiClient: MockClient };
 });
 
+const { readStdinMock } = vi.hoisted(() => ({
+	readStdinMock: vi.fn<() => Promise<string>>(() => Promise.resolve("")),
+}));
+vi.mock("../../../src/lib/stdin.js", () => ({ readStdin: readStdinMock }));
+
 function mockContext(overrides?: { getResult?: unknown; postResult?: unknown }): CommandContext {
 	return {
 		client: {
@@ -56,6 +61,30 @@ function mockContext(overrides?: { getResult?: unknown; postResult?: unknown }):
 // ---------------------------------------------------------------------------
 
 describe("auth.login", () => {
+	// Isolate from any real ELNORA_API_KEY in the environment, and default stdin
+	// to non-TTY so the --api-key-stdin path is exercisable.
+	let savedApi: string | undefined;
+	let savedMcp: string | undefined;
+	const origStdinTTY = process.stdin.isTTY;
+
+	beforeEach(() => {
+		savedApi = process.env.ELNORA_API_KEY;
+		savedMcp = process.env.ELNORA_MCP_API_KEY;
+		delete process.env.ELNORA_API_KEY;
+		delete process.env.ELNORA_MCP_API_KEY;
+		readStdinMock.mockReset();
+		readStdinMock.mockResolvedValue("");
+		Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+	});
+
+	afterEach(() => {
+		if (savedApi === undefined) delete process.env.ELNORA_API_KEY;
+		else process.env.ELNORA_API_KEY = savedApi;
+		if (savedMcp === undefined) delete process.env.ELNORA_MCP_API_KEY;
+		else process.env.ELNORA_MCP_API_KEY = savedMcp;
+		Object.defineProperty(process.stdin, "isTTY", { value: origStdinTTY, configurable: true });
+	});
+
 	test("has correct name and group", () => {
 		expect(authLogin.name).toBe("auth.login");
 		expect(authLogin.group).toBe("auth");
@@ -64,6 +93,56 @@ describe("auth.login", () => {
 	test("throws ValidationError when no apiKey provided", async () => {
 		const ctx = mockContext();
 		await expect(authLogin.execute({}, ctx)).rejects.toThrow(ValidationError);
+	});
+
+	test("defaults apiKeyStdin to false", () => {
+		expect(authLogin.inputSchema.parse({}).apiKeyStdin).toBe(false);
+	});
+
+	test("--api-key-stdin reads the key from piped stdin and saves it", async () => {
+		const { saveProfile } = await import("../../../src/lib/profiles.js");
+		readStdinMock.mockResolvedValue("elnora_live_piped_key_1234567890\n");
+		const ctx = mockContext();
+		const result = await authLogin.execute(authLogin.inputSchema.parse({ apiKeyStdin: true }), ctx);
+		expect(readStdinMock).toHaveBeenCalled();
+		expect(saveProfile).toHaveBeenCalledWith("default", "elnora_live_piped_key_1234567890");
+		expect(result).toMatchObject({ verified: true });
+	});
+
+	test("--api-key and --api-key-stdin together → ValidationError (no stdin read)", async () => {
+		const ctx = mockContext();
+		await expect(
+			authLogin.execute(
+				authLogin.inputSchema.parse({ apiKey: "elnora_live_flag_key_1234567890", apiKeyStdin: true }),
+				ctx,
+			),
+		).rejects.toThrow(ValidationError);
+		expect(readStdinMock).not.toHaveBeenCalled();
+	});
+
+	test("--api-key-stdin with a TTY stdin errors instead of hanging", async () => {
+		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+		const ctx = mockContext();
+		await expect(authLogin.execute(authLogin.inputSchema.parse({ apiKeyStdin: true }), ctx)).rejects.toThrow(
+			ValidationError,
+		);
+	});
+
+	test("--api-key-stdin with empty input → ValidationError", async () => {
+		readStdinMock.mockResolvedValue("   \n");
+		const ctx = mockContext();
+		await expect(authLogin.execute(authLogin.inputSchema.parse({ apiKeyStdin: true }), ctx)).rejects.toThrow(
+			ValidationError,
+		);
+	});
+
+	test("honors ELNORA_API_KEY when no flag/stdin key is given", async () => {
+		const { saveProfile } = await import("../../../src/lib/profiles.js");
+		process.env.ELNORA_API_KEY = "elnora_live_env_key_1234567890";
+		const ctx = mockContext();
+		const result = await authLogin.execute(authLogin.inputSchema.parse({}), ctx);
+		expect(saveProfile).toHaveBeenCalledWith("default", "elnora_live_env_key_1234567890");
+		expect(result).toMatchObject({ verified: true });
 	});
 
 	test("throws AuthError when key does not start with elnora_live_", async () => {
@@ -103,12 +182,10 @@ describe("auth.login", () => {
 		expect(authLogin.formatOutput({ profile: "work", verified: true }, "compact")).toBe("work");
 	});
 
-	test("formatOutput json returns human-friendly next steps", () => {
+	test("formatOutput json returns machine-readable JSON (guidance is on stderr)", () => {
 		const output = { profile: "default", verified: true };
 		const result = authLogin.formatOutput(output, "json");
-		expect(result).toContain('✓ Authenticated! API key saved to profile "default".');
-		expect(result).toContain("elnora projects list");
-		expect(result).toContain("elnora doctor");
+		expect(JSON.parse(result)).toEqual(output);
 	});
 });
 

--- a/__tests__/commands/config.test.ts
+++ b/__tests__/commands/config.test.ts
@@ -1,0 +1,119 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const { loadProfilesMock } = vi.hoisted(() => ({
+	loadProfilesMock: vi.fn<() => Record<string, { api_key?: string }>>(() => ({})),
+}));
+vi.mock("../../src/lib/profiles.js", () => ({ loadProfiles: loadProfilesMock }));
+
+const { addConfigCommand } = await import("../../src/commands/config.js");
+const { BASE_URL, AI_SERVER_URL, MCP_URL } = await import("../../src/lib/config.js");
+
+function captureStdout() {
+	const lines: string[] = [];
+	const spy = vi.spyOn(console, "log").mockImplementation((msg?: unknown) => {
+		lines.push(typeof msg === "string" ? msg : String(msg));
+	});
+	return { get: () => lines.join("\n"), restore: () => spy.mockRestore() };
+}
+
+function buildTestProgram(): Command {
+	const p = new Command();
+	p.option("--json", "Force JSON output", false).option("--profile <name>", "Named profile");
+	addConfigCommand(p);
+	return p;
+}
+
+describe("config show", () => {
+	let savedApi: string | undefined;
+	let savedMcp: string | undefined;
+	const origTTY = process.stdout.isTTY;
+
+	beforeEach(() => {
+		savedApi = process.env.ELNORA_API_KEY;
+		savedMcp = process.env.ELNORA_MCP_API_KEY;
+		delete process.env.ELNORA_API_KEY;
+		delete process.env.ELNORA_MCP_API_KEY;
+		loadProfilesMock.mockReturnValue({});
+		// Default to a terminal so the human key=value path is exercised; the
+		// piped-JSON behavior gets its own test.
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		if (savedApi === undefined) delete process.env.ELNORA_API_KEY;
+		else process.env.ELNORA_API_KEY = savedApi;
+		if (savedMcp === undefined) delete process.env.ELNORA_MCP_API_KEY;
+		else process.env.ELNORA_MCP_API_KEY = savedMcp;
+		Object.defineProperty(process.stdout, "isTTY", { value: origTTY, configurable: true });
+	});
+
+	test("prints stable key=value with resolved endpoints", async () => {
+		const cap = captureStdout();
+		await buildTestProgram().parseAsync(["node", "elnora", "config", "show"]);
+		const out = cap.get();
+		expect(out).toContain(`base_url=${BASE_URL}`);
+		expect(out).toContain(`ai_server_url=${AI_SERVER_URL}`);
+		expect(out).toContain(`mcp_url=${MCP_URL}`);
+		expect(out).toContain("active_profile=default");
+		expect(out).toContain("key_source=none");
+		cap.restore();
+	});
+
+	test("--json emits the same fields as JSON", async () => {
+		const cap = captureStdout();
+		await buildTestProgram().parseAsync(["node", "elnora", "--json", "config", "show"]);
+		const parsed = JSON.parse(cap.get());
+		expect(parsed.base_url).toBe(BASE_URL);
+		expect(parsed.mcp_url).toBe(MCP_URL);
+		expect(parsed.active_profile).toBe("default");
+		expect(parsed.key_source).toBe("none");
+		cap.restore();
+	});
+
+	test("key_source: env wins over profile", async () => {
+		process.env.ELNORA_API_KEY = "elnora_live_env";
+		loadProfilesMock.mockReturnValue({ default: { api_key: "elnora_live_profile" } });
+		const cap = captureStdout();
+		await buildTestProgram().parseAsync(["node", "elnora", "config", "show"]);
+		expect(cap.get()).toContain("key_source=env:ELNORA_API_KEY");
+		cap.restore();
+	});
+
+	test("key_source: profile when no env key", async () => {
+		loadProfilesMock.mockReturnValue({ default: { api_key: "elnora_live_profile" } });
+		const cap = captureStdout();
+		await buildTestProgram().parseAsync(["node", "elnora", "config", "show"]);
+		expect(cap.get()).toContain("key_source=profile:default");
+		cap.restore();
+	});
+
+	test("honors --profile for active_profile and key source", async () => {
+		loadProfilesMock.mockReturnValue({ work: { api_key: "elnora_live_work" } });
+		const cap = captureStdout();
+		await buildTestProgram().parseAsync(["node", "elnora", "--profile", "work", "config", "show"]);
+		const out = cap.get();
+		expect(out).toContain("active_profile=work");
+		expect(out).toContain("key_source=profile:work");
+		cap.restore();
+	});
+
+	test("never prints the raw key value", async () => {
+		process.env.ELNORA_API_KEY = "elnora_live_supersecret_value";
+		const cap = captureStdout();
+		await buildTestProgram().parseAsync(["node", "elnora", "config", "show"]);
+		expect(cap.get()).not.toContain("supersecret");
+		cap.restore();
+	});
+
+	test("emits JSON when piped/redirected (non-TTY), no flag required", async () => {
+		Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+		const cap = captureStdout();
+		await buildTestProgram().parseAsync(["node", "elnora", "config", "show"]);
+		const parsed = JSON.parse(cap.get());
+		expect(parsed.base_url).toBe(BASE_URL);
+		expect(parsed.active_profile).toBe("default");
+		cap.restore();
+	});
+});

--- a/__tests__/commands/doctor.test.ts
+++ b/__tests__/commands/doctor.test.ts
@@ -11,8 +11,17 @@ vi.mock("node:os", async () => {
 	return { ...actual, homedir: () => TEST_HOME };
 });
 
+// Make the shadow-install check deterministic (default: no installs found → the
+// check skips, independent of the test machine's real PATH). Individual tests
+// override detectAllInstalls to exercise the warn path. uninstallCommandFor stays real.
+vi.mock("../../src/lib/install-discovery.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../src/lib/install-discovery.js")>();
+	return { ...actual, detectAllInstalls: vi.fn(() => []) };
+});
+
 // Dynamic import after mock so constants are built with mocked homedir
 const { addDoctorCommand } = await import("../../src/commands/doctor.js");
+const { detectAllInstalls } = await import("../../src/lib/install-discovery.js");
 const { VERSION } = await import("../../src/lib/config.js");
 
 // Helper to capture console.error output
@@ -300,14 +309,62 @@ describe("elnora doctor", () => {
 
 	// ----- skip is not counted as pass -----
 	test("does not report 'All checks passed' when checks were skipped", async () => {
-		// Fresh machine: Claude Code never installed → its 3 checks skip.
+		// Fresh machine: Claude Code never installed → its 3 checks skip, plus the
+		// shadow-install check skips (no active install resolvable under the test).
 		const capture = captureStderr();
 		const program = new Command();
 		addDoctorCommand(program);
 		await program.parseAsync(["node", "elnora", "doctor"]);
 		const output = capture.getOutput();
 		expect(output).not.toContain("All checks passed");
-		expect(output).toMatch(/3 skipped/);
+		expect(output).toMatch(/4 skipped/);
+		capture.restore();
+	});
+
+	// ----- shadow-install detection -----
+	test("warns about shadow installs with per-source uninstall commands", async () => {
+		vi.mocked(detectAllInstalls).mockReturnValueOnce([
+			{
+				path: "/home/u/.elnora/bin/elnora",
+				realPath: "/home/u/.elnora/bin/elnora",
+				pathDir: "/home/u/.elnora/bin",
+				source: "binary",
+				active: true,
+			},
+			{
+				path: "/usr/local/bin/elnora",
+				realPath: "/usr/local/bin/elnora",
+				pathDir: "/usr/local/bin",
+				source: "npm",
+				active: false,
+			},
+		]);
+		const capture = captureStderr();
+		const program = new Command();
+		addDoctorCommand(program);
+		await program.parseAsync(["node", "elnora", "doctor"]);
+		const output = capture.getOutput();
+		expect(output).toMatch(/![^\n]*Shadow installs/);
+		expect(output).toContain("/usr/local/bin/elnora");
+		expect(output).toContain("npm uninstall -g @elnora-ai/cli");
+		capture.restore();
+	});
+
+	test("passes when there is a single (active) install", async () => {
+		vi.mocked(detectAllInstalls).mockReturnValueOnce([
+			{
+				path: "/home/u/.elnora/bin/elnora",
+				realPath: "/home/u/.elnora/bin/elnora",
+				pathDir: "/home/u/.elnora/bin",
+				source: "binary",
+				active: true,
+			},
+		]);
+		const capture = captureStderr();
+		const program = new Command();
+		addDoctorCommand(program);
+		await program.parseAsync(["node", "elnora", "doctor"]);
+		expect(capture.getOutput()).toMatch(/✓[^\n]*No shadow installs/);
 		capture.restore();
 	});
 });

--- a/__tests__/lib/banner.test.ts
+++ b/__tests__/lib/banner.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { maybePrintBanner, renderBanner } from "../../src/lib/banner.js";
+
+const ENV = ["NO_COLOR", "FORCE_COLOR", "CI", "GITHUB_ACTIONS"] as const;
+
+describe("banner", () => {
+	const origTTY = process.stderr.isTTY;
+	const saved: Record<string, string | undefined> = {};
+	let writeSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		for (const k of ENV) {
+			saved[k] = process.env[k];
+			delete process.env[k];
+		}
+		Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+		writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+	});
+
+	afterEach(() => {
+		for (const k of ENV) {
+			if (saved[k] === undefined) delete process.env[k];
+			else process.env[k] = saved[k];
+		}
+		Object.defineProperty(process.stderr, "isTTY", { value: origTTY, configurable: true });
+		vi.restoreAllMocks();
+	});
+
+	test("renderBanner contains the wordmark and version", () => {
+		const b = renderBanner();
+		expect(b).toContain("ELNORA");
+		expect(b).toMatch(/v\d+\.\d+\.\d+/);
+	});
+
+	test("NO_COLOR → no ANSI escapes in the banner", () => {
+		process.env.NO_COLOR = "1";
+		expect(renderBanner()).not.toContain("\x1b[");
+	});
+
+	test("bare `elnora` on a TTY prints to stderr", () => {
+		maybePrintBanner(["node", "elnora"]);
+		expect(writeSpy).toHaveBeenCalled();
+		expect(String(writeSpy.mock.calls[0][0])).toContain("ELNORA");
+	});
+
+	test("top-level --help prints", () => {
+		maybePrintBanner(["node", "elnora", "--help"]);
+		expect(writeSpy).toHaveBeenCalled();
+	});
+
+	test("silent when stderr is not a TTY (piped)", () => {
+		Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
+		maybePrintBanner(["node", "elnora"]);
+		expect(writeSpy).not.toHaveBeenCalled();
+	});
+
+	test("silent for a subcommand", () => {
+		maybePrintBanner(["node", "elnora", "tasks", "list"]);
+		expect(writeSpy).not.toHaveBeenCalled();
+	});
+
+	test("silent for --version", () => {
+		maybePrintBanner(["node", "elnora", "--version"]);
+		expect(writeSpy).not.toHaveBeenCalled();
+	});
+
+	test("silent for subcommand --help", () => {
+		maybePrintBanner(["node", "elnora", "tasks", "--help"]);
+		expect(writeSpy).not.toHaveBeenCalled();
+	});
+
+	test("silent with --quiet", () => {
+		maybePrintBanner(["node", "elnora", "--quiet"]);
+		expect(writeSpy).not.toHaveBeenCalled();
+	});
+
+	test("silent in CI even on a TTY", () => {
+		process.env.CI = "1";
+		maybePrintBanner(["node", "elnora"]);
+		expect(writeSpy).not.toHaveBeenCalled();
+	});
+});

--- a/__tests__/lib/config.test.ts
+++ b/__tests__/lib/config.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, test } from "vitest";
-import { BASE_URL, buildUrl, DEFAULT_PAGE_SIZE, ENDPOINTS, MAX_PAGE_SIZE } from "../../src/lib/config.js";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { BASE_URL, buildUrl, DEFAULT_PAGE_SIZE, ENDPOINTS, MAX_PAGE_SIZE, MCP_URL } from "../../src/lib/config.js";
 
 describe("config constants", () => {
 	test("BASE_URL is platform.elnora.ai", () => {
 		expect(BASE_URL).toBe("https://platform.elnora.ai/api/v1");
+	});
+
+	test("MCP_URL defaults to the production MCP endpoint", () => {
+		expect(MCP_URL).toBe("https://mcp.elnora.ai/mcp");
 	});
 
 	test("ENDPOINTS has projects endpoint", () => {
@@ -46,5 +50,27 @@ describe("buildUrl", () => {
 
 	test("throws for unknown endpoint", () => {
 		expect(() => buildUrl("nonexistent")).toThrow("Unknown endpoint: nonexistent");
+	});
+});
+
+describe("env-var URL overrides", () => {
+	afterEach(() => {
+		vi.resetModules();
+		delete process.env.ELNORA_MCP_URL;
+		delete process.env.ELNORA_API_URL;
+	});
+
+	test("MCP_URL honors ELNORA_MCP_URL", async () => {
+		vi.resetModules();
+		process.env.ELNORA_MCP_URL = "https://staging-mcp.example/mcp";
+		const fresh = await import("../../src/lib/config.js");
+		expect(fresh.MCP_URL).toBe("https://staging-mcp.example/mcp");
+	});
+
+	test("BASE_URL honors ELNORA_API_URL", async () => {
+		vi.resetModules();
+		process.env.ELNORA_API_URL = "https://staging.example/api/v1";
+		const fresh = await import("../../src/lib/config.js");
+		expect(fresh.BASE_URL).toBe("https://staging.example/api/v1");
 	});
 });

--- a/__tests__/lib/errors.test.ts
+++ b/__tests__/lib/errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { z } from "zod";
 import {
 	AuthError,
 	ElnoraError,
@@ -11,6 +12,7 @@ import {
 	ServerError,
 	scrub,
 	scrubData,
+	toValidationError,
 	ValidationError,
 } from "../../src/lib/errors.js";
 
@@ -98,6 +100,48 @@ describe("getExitCode", () => {
 	test("returns 1 for unknown errors", () => {
 		expect(getExitCode(new Error("generic"))).toBe(1);
 		expect(getExitCode(new ElnoraError("base"))).toBe(1);
+	});
+});
+
+describe("toValidationError", () => {
+	test("turns a ZodError into a one-line ValidationError (field: message), exit 2", () => {
+		const schema = z.object({ pageSize: z.number().max(100) });
+		let caught: unknown;
+		try {
+			schema.parse({ pageSize: 999 });
+		} catch (e) {
+			caught = e;
+		}
+		const err = toValidationError(caught);
+		expect(err).toBeInstanceOf(ValidationError);
+		expect(err.message).toContain("pageSize");
+		expect(getExitCode(err)).toBe(2);
+		// Must NOT be raw serialized ZodError JSON.
+		expect(err.message).not.toContain("invalid_format");
+		expect(err.message).not.toMatch(/^\[/);
+	});
+
+	test("summarizes multiple issues with a count", () => {
+		const schema = z.object({ a: z.string(), b: z.string() });
+		let caught: unknown;
+		try {
+			schema.parse({});
+		} catch (e) {
+			caught = e;
+		}
+		const err = toValidationError(caught);
+		expect(err.message).toMatch(/\+\d+ more/);
+	});
+
+	test("passes non-Zod errors through unchanged", () => {
+		const original = new AuthError("nope");
+		expect(toValidationError(original)).toBe(original);
+	});
+
+	test("wraps non-Error values", () => {
+		const err = toValidationError("boom");
+		expect(err).toBeInstanceOf(Error);
+		expect(err.message).toBe("boom");
 	});
 });
 

--- a/__tests__/lib/install-discovery.test.ts
+++ b/__tests__/lib/install-discovery.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test, vi } from "vitest";
+
+// In-memory filesystem for the discovery scan: which paths "exist" as files, and
+// their realpath mappings (for symlink/dedupe scenarios).
+const fsState = vi.hoisted(() => ({
+	files: new Set<string>(),
+	links: new Map<string, string>(),
+}));
+
+vi.mock("node:fs", () => ({
+	existsSync: (p: string) => fsState.files.has(p),
+	statSync: (p: string) => ({ isFile: () => fsState.files.has(p) }),
+	realpathSync: (p: string) => fsState.links.get(p) ?? p,
+}));
+
+const { discoverInstalls, uninstallCommandFor } = await import("../../src/lib/install-discovery.js");
+
+function reset(files: string[], links: Record<string, string> = {}) {
+	fsState.files = new Set(files);
+	fsState.links = new Map(Object.entries(links));
+}
+
+const POSIX = {
+	platform: "linux" as NodeJS.Platform,
+	pathExt: "",
+	home: "/home/u",
+	installDirOverride: undefined,
+};
+
+describe("discoverInstalls", () => {
+	test("classifies a single npm install and marks it active", () => {
+		reset(["/proj/node_modules/.bin/elnora"]);
+		const installs = discoverInstalls({
+			...POSIX,
+			pathVar: "/proj/node_modules/.bin:/usr/bin",
+			execPath: "/usr/bin/node",
+			argv1: "/proj/node_modules/.bin/elnora",
+		});
+		expect(installs).toHaveLength(1);
+		expect(installs[0].source).toBe("npm");
+		expect(installs[0].active).toBe(true);
+	});
+
+	test("dedupes two PATH entries that resolve to the same realpath (symlink)", () => {
+		reset(["/opt/homebrew/bin/elnora", "/usr/local/bin/elnora"], {
+			"/opt/homebrew/bin/elnora": "/opt/homebrew/Cellar/elnora/2.0.5/bin/elnora",
+			"/usr/local/bin/elnora": "/opt/homebrew/Cellar/elnora/2.0.5/bin/elnora",
+		});
+		const installs = discoverInstalls({
+			...POSIX,
+			pathVar: "/opt/homebrew/bin:/usr/local/bin",
+			execPath: "/usr/bin/node",
+			argv1: "/x",
+		});
+		expect(installs).toHaveLength(1);
+		expect(installs[0].source).toBe("homebrew");
+	});
+
+	test("finds multiple distinct installs with exactly one active", () => {
+		reset(["/home/u/.elnora/bin/elnora", "/usr/local/lib/node_modules/.bin/elnora", "/opt/homebrew/bin/elnora"], {
+			"/opt/homebrew/bin/elnora": "/opt/homebrew/Cellar/elnora/2.0.5/bin/elnora",
+		});
+		const installs = discoverInstalls({
+			...POSIX,
+			pathVar: "/home/u/.elnora/bin:/usr/local/lib/node_modules/.bin:/opt/homebrew/bin",
+			execPath: "/home/u/.elnora/bin/elnora", // packaged binary is the active one
+			argv1: "/home/u/.elnora/bin/elnora",
+		});
+		expect(installs).toHaveLength(3);
+		expect(installs.filter((i) => i.active)).toHaveLength(1);
+		expect(installs.find((i) => i.active)?.source).toBe("binary");
+		expect(installs.map((i) => i.source).sort()).toEqual(["binary", "homebrew", "npm"]);
+	});
+
+	test("classifies an entry whose realpath is a .ts source as dev", () => {
+		reset(["/work/.bin/elnora"], { "/work/.bin/elnora": "/work/elnora-cli/src/cli.ts" });
+		const installs = discoverInstalls({
+			...POSIX,
+			pathVar: "/work/.bin",
+			execPath: "/usr/bin/node",
+			argv1: "/work/elnora-cli/src/cli.ts",
+		});
+		expect(installs[0].source).toBe("dev");
+	});
+
+	test("Windows: probes PATHEXT candidates", () => {
+		reset(["C:\\Users\\u\\.elnora\\bin\\elnora.exe"]);
+		const installs = discoverInstalls({
+			platform: "win32",
+			pathExt: ".EXE;.CMD",
+			home: "C:\\Users\\u",
+			installDirOverride: undefined,
+			pathVar: "C:\\Users\\u\\.elnora\\bin",
+			execPath: "C:\\Users\\u\\.elnora\\bin\\elnora.exe",
+			argv1: "C:\\Users\\u\\.elnora\\bin\\elnora.exe",
+		});
+		expect(installs).toHaveLength(1);
+		expect(installs[0].source).toBe("binary");
+		expect(installs[0].active).toBe(true);
+	});
+
+	test("Windows npm global: collapses same-dir shims, classifies npm, detects active via prefix", () => {
+		// npm writes BOTH an extensionless shim and elnora.cmd into the prefix dir;
+		// a separate packaged binary lives in ~/.elnora/bin.
+		reset([
+			"C:\\Users\\u\\AppData\\Roaming\\npm\\elnora.cmd",
+			"C:\\Users\\u\\AppData\\Roaming\\npm\\elnora",
+			"C:\\Users\\u\\.elnora\\bin\\elnora.exe",
+		]);
+		const installs = discoverInstalls({
+			platform: "win32",
+			pathExt: ".EXE;.CMD",
+			home: "C:\\Users\\u",
+			installDirOverride: undefined,
+			pathVar: "C:\\Users\\u\\AppData\\Roaming\\npm;C:\\Users\\u\\.elnora\\bin",
+			execPath: "C:\\Program Files\\nodejs\\node.exe",
+			argv1: "C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@elnora-ai\\cli\\dist\\cli.js",
+		});
+		// The two shims in the npm dir collapse to ONE install (not double-counted).
+		expect(installs).toHaveLength(2);
+		const npm = installs.find((i) => i.source === "npm");
+		expect(npm).toBeDefined();
+		expect(npm?.active).toBe(true); // matched via npm prefix (shims aren't symlinks)
+		const binary = installs.find((i) => i.source === "binary");
+		expect(binary?.active).toBe(false); // the shadow
+	});
+});
+
+describe("uninstallCommandFor", () => {
+	const base = { path: "/p/elnora", realPath: "/p/elnora", pathDir: "/p", active: false };
+	test("npm / homebrew commands", () => {
+		expect(uninstallCommandFor({ ...base, source: "npm" })).toBe("npm uninstall -g @elnora-ai/cli");
+		expect(uninstallCommandFor({ ...base, source: "homebrew" })).toBe("brew uninstall elnora");
+	});
+	test("dev returns null (not a competing install)", () => {
+		expect(uninstallCommandFor({ ...base, source: "dev" })).toBeNull();
+	});
+	test("binary/unknown returns a filesystem removal of the specific path", () => {
+		const cmd = uninstallCommandFor({ ...base, source: "binary" });
+		expect(cmd).toContain("/p/elnora");
+		expect(cmd).toMatch(/^(rm|Remove-Item)/);
+	});
+});

--- a/__tests__/lib/output.test.ts
+++ b/__tests__/lib/output.test.ts
@@ -93,3 +93,100 @@ describe("formatOutput", () => {
 		expect(result).toBe("");
 	});
 });
+
+describe("table format", () => {
+	test("renders an array as an aligned table with header + separator", () => {
+		const result = formatOutput(
+			[
+				{ id: "1", name: "Alpha" },
+				{ id: "22", name: "Beta" },
+			],
+			{ format: "table" },
+		);
+		const lines = result.split("\n");
+		expect(lines[0]).toMatch(/^id\s+name$/);
+		expect(lines[1]).toMatch(/^-+\s+-+$/);
+		expect(lines[2]).toContain("Alpha");
+		expect(lines[3]).toContain("Beta");
+	});
+
+	test("renders an items wrapper as a table with a metadata footer", () => {
+		const result = formatOutput({ items: [{ id: "1", name: "A" }], totalCount: 99, page: 1 }, { format: "table" });
+		expect(result).toContain("id");
+		expect(result).toContain("name");
+		// Sibling scalars (pagination context) surfaced in a footer, not dropped.
+		expect(result).toContain("totalCount=99");
+		expect(result).toContain("page=1");
+	});
+
+	test("raw string is not redacted (lossless file content)", () => {
+		// A 40+ char alphanumeric-with-digit string would be scrubbed if treated as data.
+		const content = "seqid_ABCDEFGHIJ0123456789KLMNOPQRSTUVWX42";
+		expect(formatOutput(content, { format: "table" })).toBe(content);
+		expect(formatOutput(content, { format: "json" })).toBe(JSON.stringify(content, null, 2));
+	});
+
+	test("renders a single object as a key/value block", () => {
+		const result = formatOutput({ id: "1", name: "Test" }, { format: "table" });
+		expect(result).toMatch(/id\s+1/);
+		expect(result).toMatch(/name\s+Test/);
+		expect(result).not.toContain("---"); // not a columnar table
+	});
+
+	test("empty list → No results.", () => {
+		expect(formatOutput([], { format: "table" })).toBe("No results.");
+	});
+
+	test("raw string passes through unboxed", () => {
+		expect(formatOutput("# A protocol\nstep 1", { format: "table" })).toBe("# A protocol\nstep 1");
+	});
+
+	test("still scrubs credentials", () => {
+		const result = formatOutput([{ key: "elnora_live_orgA_abcdefgh12345678" }], { format: "table" });
+		expect(result).toContain("[REDACTED]");
+		expect(result).not.toContain("elnora_live_");
+	});
+
+	test("applies --fields before rendering", () => {
+		const result = formatOutput([{ id: "1", name: "A", secret: "x" }], { format: "table", fields: ["id", "name"] });
+		expect(result).toContain("name");
+		expect(result).not.toContain("secret");
+	});
+});
+
+describe("markdown format", () => {
+	test("renders an array as a GitHub pipe table", () => {
+		const result = formatOutput(
+			[
+				{ id: "1", name: "A" },
+				{ id: "2", name: "B" },
+			],
+			{ format: "markdown" },
+		);
+		const lines = result.split("\n");
+		expect(lines[0]).toBe("| id | name |");
+		expect(lines[1]).toBe("| --- | --- |");
+		expect(lines[2]).toBe("| 1 | A |");
+	});
+
+	test("renders a single object as headed key/value", () => {
+		const result = formatOutput({ id: "1", name: "Test" }, { format: "markdown" });
+		expect(result).toContain("**id:** 1");
+		expect(result).toContain("**name:** Test");
+	});
+
+	test("escapes pipe characters in cells", () => {
+		const result = formatOutput([{ name: "a|b" }], { format: "markdown" });
+		expect(result).toContain("a\\|b");
+	});
+
+	test("escapes backslashes as well as pipes (complete escaping)", () => {
+		const result = formatOutput([{ path: "a\\b|c" }], { format: "markdown" });
+		// input a\b|c → a\\b\|c
+		expect(result).toContain("a\\\\b\\|c");
+	});
+
+	test("empty list → italic No results", () => {
+		expect(formatOutput([], { format: "markdown" })).toBe("_No results._");
+	});
+});

--- a/__tests__/lib/output.test.ts
+++ b/__tests__/lib/output.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { filterFields, formatOutput } from "../../src/lib/output.js";
 
 describe("filterFields", () => {
@@ -188,5 +188,42 @@ describe("markdown format", () => {
 
 	test("empty list → italic No results", () => {
 		expect(formatOutput([], { format: "markdown" })).toBe("_No results._");
+	});
+});
+
+describe("table hyperlinks (single-object view)", () => {
+	const saved: Record<string, string | undefined> = {};
+	beforeEach(() => {
+		saved.NO_COLOR = process.env.NO_COLOR;
+		saved.FORCE_COLOR = process.env.FORCE_COLOR;
+		delete process.env.NO_COLOR;
+		process.env.FORCE_COLOR = "1"; // force color so OSC 8 is emitted
+	});
+	afterEach(() => {
+		if (saved.NO_COLOR === undefined) delete process.env.NO_COLOR;
+		else process.env.NO_COLOR = saved.NO_COLOR;
+		if (saved.FORCE_COLOR === undefined) delete process.env.FORCE_COLOR;
+		else process.env.FORCE_COLOR = saved.FORCE_COLOR;
+	});
+
+	test("wraps a URL value in an OSC 8 link", () => {
+		const result = formatOutput({ url: "https://elnora.ai/x" }, { format: "table" });
+		expect(result).toContain("\x1b]8;;https://elnora.ai/x\x07");
+	});
+
+	test("leaves non-URL values plain", () => {
+		const result = formatOutput({ name: "Alpha" }, { format: "table" });
+		expect(result).not.toContain("\x1b]8;;");
+	});
+
+	test("does not hyperlink inside columnar list tables (would break alignment)", () => {
+		const result = formatOutput([{ url: "https://elnora.ai/x" }], { format: "table" });
+		expect(result).not.toContain("\x1b]8;;");
+	});
+
+	test("does not wrap a URL value containing control chars in an OSC 8 link", () => {
+		const evil = `https://a${String.fromCharCode(0x1b)}b`;
+		const result = formatOutput({ url: evil }, { format: "table" });
+		expect(result).not.toContain("\x1b]8;;");
 	});
 });

--- a/__tests__/lib/stdin.test.ts
+++ b/__tests__/lib/stdin.test.ts
@@ -1,0 +1,49 @@
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, test } from "vitest";
+import { readStdin } from "../../src/lib/stdin.js";
+
+const realStdin = process.stdin;
+
+function useFakeStdin(isTTY: boolean): PassThrough & { isTTY?: boolean } {
+	const fake = new PassThrough() as PassThrough & { isTTY?: boolean };
+	fake.isTTY = isTTY;
+	Object.defineProperty(process, "stdin", { value: fake, configurable: true });
+	return fake;
+}
+
+describe("readStdin", () => {
+	afterEach(() => {
+		Object.defineProperty(process, "stdin", { value: realStdin, configurable: true });
+	});
+
+	test("resolves '' immediately when stdin is a TTY (no hang)", async () => {
+		useFakeStdin(true);
+		await expect(readStdin()).resolves.toBe("");
+	});
+
+	test("accumulates piped chunks until end", async () => {
+		const fake = useFakeStdin(false);
+		const p = readStdin();
+		fake.write("abc");
+		fake.write("def");
+		fake.end();
+		await expect(p).resolves.toBe("abcdef");
+	});
+
+	test("decodes a multi-byte UTF-8 char split across chunks", async () => {
+		const fake = useFakeStdin(false);
+		const p = readStdin();
+		// "é" = 0xC3 0xA9, delivered one byte at a time.
+		fake.write(Buffer.from([0xc3]));
+		fake.write(Buffer.from([0xa9]));
+		fake.end();
+		await expect(p).resolves.toBe("é");
+	});
+
+	test("rejects on a stream error", async () => {
+		const fake = useFakeStdin(false);
+		const p = readStdin();
+		fake.emit("error", new Error("boom"));
+		await expect(p).rejects.toThrow("boom");
+	});
+});

--- a/__tests__/lib/stream-renderer.test.ts
+++ b/__tests__/lib/stream-renderer.test.ts
@@ -30,6 +30,16 @@ describe("StreamRenderer", () => {
 		expect(stderrWrite).toHaveBeenCalled();
 	});
 
+	test("quiet:true suppresses spinner/status chrome but still emits tokens", () => {
+		const renderer = new StreamRenderer({ quiet: true });
+		renderer.renderEvent({ type: "think", content: "Planning approach..." });
+		renderer.renderEvent({ type: "tool_start", tool: "pubmed_search" });
+		renderer.renderEvent({ type: "progress", content: "Found 8 papers" });
+		expect(stderrWrite).not.toHaveBeenCalled();
+		renderer.renderEvent({ type: "token", content: "result" });
+		expect(stdoutWrite).toHaveBeenCalledWith("result");
+	});
+
 	test("writes tool_start event to stderr", () => {
 		const renderer = new StreamRenderer();
 		renderer.renderEvent({ type: "tool_start", tool: "pubmed_search" });

--- a/__tests__/lib/tty.test.ts
+++ b/__tests__/lib/tty.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { isColorEnabled, resolveDefaultFormat } from "../../src/lib/tty.js";
+import { hyperlink, isColorEnabled, resolveDefaultFormat } from "../../src/lib/tty.js";
 
 const ENV_KEYS = ["NO_COLOR", "FORCE_COLOR", "TERM"] as const;
 
@@ -76,5 +76,50 @@ describe("isColorEnabled", () => {
 		expect(isColorEnabled()).toBe(true);
 		setTTY(false);
 		expect(isColorEnabled()).toBe(false);
+	});
+});
+
+describe("hyperlink", () => {
+	const origTTY = process.stdout.isTTY;
+	const saved: Record<string, string | undefined> = {};
+	beforeEach(() => {
+		for (const k of ENV_KEYS) {
+			saved[k] = process.env[k];
+			delete process.env[k];
+		}
+	});
+	afterEach(() => {
+		for (const k of ENV_KEYS) {
+			if (saved[k] === undefined) delete process.env[k];
+			else process.env[k] = saved[k];
+		}
+		Object.defineProperty(process.stdout, "isTTY", { value: origTTY, configurable: true });
+	});
+
+	test("wraps text in an OSC 8 sequence when color is enabled", () => {
+		process.env.FORCE_COLOR = "1";
+		expect(hyperlink("https://x.test/a", "click")).toBe("\x1b]8;;https://x.test/a\x07click\x1b]8;;\x07");
+	});
+
+	test("returns bare text when color is disabled", () => {
+		process.env.NO_COLOR = "1";
+		expect(hyperlink("https://x.test/a", "click")).toBe("click");
+	});
+
+	test("returns bare text for an empty url", () => {
+		process.env.FORCE_COLOR = "1";
+		expect(hyperlink("", "click")).toBe("click");
+	});
+
+	test("strips control bytes from the URL so it can't inject terminal escapes", () => {
+		process.env.FORCE_COLOR = "1";
+		const ESC = String.fromCharCode(0x1b);
+		const BEL = String.fromCharCode(0x07);
+		const evil = `https://a${ESC}]0;pwned${BEL}b`;
+		const out = hyperlink(evil, "click");
+		// A clean OSC 8 sequence has exactly two ESC and two BEL (the markers); an
+		// unsanitized URL would add a third of each.
+		expect([...out].filter((c) => c === ESC)).toHaveLength(2);
+		expect([...out].filter((c) => c === BEL)).toHaveLength(2);
 	});
 });

--- a/__tests__/lib/tty.test.ts
+++ b/__tests__/lib/tty.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { isColorEnabled, resolveDefaultFormat } from "../../src/lib/tty.js";
+
+const ENV_KEYS = ["NO_COLOR", "FORCE_COLOR", "TERM"] as const;
+
+function setTTY(value: boolean) {
+	Object.defineProperty(process.stdout, "isTTY", { value, configurable: true });
+}
+
+describe("resolveDefaultFormat", () => {
+	const orig = process.stdout.isTTY;
+	afterEach(() => {
+		Object.defineProperty(process.stdout, "isTTY", { value: orig, configurable: true });
+	});
+
+	test("table on an interactive terminal", () => {
+		setTTY(true);
+		expect(resolveDefaultFormat()).toBe("table");
+	});
+
+	test("json when piped/redirected (non-TTY) — keeps pipes/agents on JSON", () => {
+		setTTY(false);
+		expect(resolveDefaultFormat()).toBe("json");
+	});
+});
+
+describe("isColorEnabled", () => {
+	const origTTY = process.stdout.isTTY;
+	const saved: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		for (const k of ENV_KEYS) {
+			saved[k] = process.env[k];
+			delete process.env[k];
+		}
+	});
+	afterEach(() => {
+		for (const k of ENV_KEYS) {
+			if (saved[k] === undefined) delete process.env[k];
+			else process.env[k] = saved[k];
+		}
+		Object.defineProperty(process.stdout, "isTTY", { value: origTTY, configurable: true });
+	});
+
+	test("NO_COLOR wins over FORCE_COLOR (the path --no-color uses via the env shim)", () => {
+		process.env.FORCE_COLOR = "1";
+		process.env.NO_COLOR = "1";
+		expect(isColorEnabled()).toBe(false);
+	});
+
+	test("NO_COLOR (non-empty) disables color", () => {
+		process.env.NO_COLOR = "1";
+		expect(isColorEnabled()).toBe(false);
+	});
+
+	test("empty NO_COLOR does NOT disable color", () => {
+		process.env.NO_COLOR = "";
+		setTTY(true);
+		expect(isColorEnabled()).toBe(true);
+	});
+
+	test("FORCE_COLOR enables color even when non-TTY", () => {
+		process.env.FORCE_COLOR = "1";
+		setTTY(false);
+		expect(isColorEnabled()).toBe(true);
+	});
+
+	test("TERM=dumb disables color", () => {
+		process.env.TERM = "dumb";
+		setTTY(true);
+		expect(isColorEnabled()).toBe(false);
+	});
+
+	test("defaults to stdout TTY state", () => {
+		setTTY(true);
+		expect(isColorEnabled()).toBe(true);
+		setTTY(false);
+		expect(isColorEnabled()).toBe(false);
+	});
+});

--- a/__tests__/lib/update-check.test.ts
+++ b/__tests__/lib/update-check.test.ts
@@ -12,7 +12,21 @@ vi.mock("../../src/lib/install-method.js", () => ({
 	),
 }));
 
-const { showUpdateNotice } = await import("../../src/lib/update-check.js");
+const { showUpdateNotice, sanitizeVersion } = await import("../../src/lib/update-check.js");
+
+describe("sanitizeVersion", () => {
+	test("accepts and canonicalizes a plain release version", () => {
+		expect(sanitizeVersion("2.0.5")).toBe("2.0.5");
+		expect(sanitizeVersion("2.01.5")).toBe("2.1.5");
+	});
+
+	test("rejects prereleases, junk, and traversal-looking input", () => {
+		expect(sanitizeVersion("2.0.5-beta.1")).toBeNull();
+		expect(sanitizeVersion("not-a-version")).toBeNull();
+		expect(sanitizeVersion("../../etc/passwd")).toBeNull();
+		expect(sanitizeVersion("")).toBeNull();
+	});
+});
 
 describe("showUpdateNotice", () => {
 	let writes: string[];

--- a/skills/elnora-platform/SKILL.md
+++ b/skills/elnora-platform/SKILL.md
@@ -33,6 +33,10 @@ Look for tools prefixed `mcp__elnora__` in your available tools. Each domain-spe
 
 **Never fabricate tool names.** This skill routes to sub-skills; each sub-skill lists its valid commands and their MCP equivalents.
 
+## Troubleshooting
+
+If anything looks wrong — auth errors, unexpected hosts, or connectivity failures — run `elnora doctor` first. It reports the actual API / AI-server / MCP hosts, auth state, version, and connectivity. Run `elnora config show` to print the resolved endpoints and active profile. Do not guess hostnames or URLs.
+
 ## Invocation
 
 ```bash

--- a/src/adapters/cli.ts
+++ b/src/adapters/cli.ts
@@ -18,8 +18,18 @@ import type { CommandContext } from "../core/command.js";
 import type { CommandRegistry } from "../core/registry.js";
 import { ElnoraApiClient } from "../lib/client.js";
 import { VERSION } from "../lib/config.js";
-import { formatErrorForHuman, formatErrorPayload, getExitCode } from "../lib/errors.js";
+import {
+	formatErrorForHuman,
+	formatErrorPayload,
+	getExitCode,
+	toValidationError,
+	ValidationError,
+} from "../lib/errors.js";
 import { formatOutput, type OutputFormat } from "../lib/output.js";
+import { resolveDefaultFormat } from "../lib/tty.js";
+
+/** Output formats accepted by --output / --json / --md. */
+const ALLOWED_FORMATS: ReadonlySet<string> = new Set(["json", "csv", "table", "markdown"]);
 
 // ---------------------------------------------------------------------------
 // Zod schema introspection
@@ -166,10 +176,16 @@ export function buildProgram(registry: CommandRegistry): Command {
 		.description("Elnora AI Platform CLI")
 		.version(VERSION)
 		.option("--compact", "Token-efficient minimal output", false)
-		.option("--output <format>", "Output format (json, csv)", "json")
+		.option(
+			"--output <format>",
+			"Output format: json, csv, table, markdown (default: table on a terminal, json when piped)",
+		)
+		.option("--md", "Markdown output (shorthand for --output markdown)", false)
 		.option("--fields <fields>", "Comma-separated fields to include")
 		.option("--profile <name>", "Named profile to use")
-		.option("--json", "Force JSON output", false);
+		.option("--json", "Force JSON output (even on a terminal)", false)
+		.option("--quiet", "Suppress non-essential output (spinners, update notices)", false)
+		.option("--no-color", "Disable colored output");
 
 	for (const group of registry.groups()) {
 		const groupCmd = new Command(group).description(`Manage ${group}`);
@@ -241,21 +257,49 @@ export function buildProgram(registry: CommandRegistry): Command {
 						? (new ElnoraApiClient("placeholder") as unknown as CommandContext["client"])
 						: ElnoraApiClient.fromEnv(profileName);
 
+					// Resolve output format. Precedence: --json > --md > --output <fmt> >
+					// --compact (implies json) > (terminal ? table : json). Non-TTY
+					// defaults to json so pipes and agents are unaffected by the
+					// interactive table default.
+					const compact = Boolean(parentOpts.compact);
+					const explicitFormat = parentOpts.json
+						? "json"
+						: parentOpts.md
+							? "markdown"
+							: (parentOpts.output as string | undefined);
+					if (explicitFormat && !ALLOWED_FORMATS.has(explicitFormat)) {
+						throw new ValidationError(
+							`Unknown output format: ${explicitFormat}`,
+							`Valid formats: ${[...ALLOWED_FORMATS].join(", ")}.`,
+						);
+					}
+					// --compact is a JSON modifier, not a format. With no explicit format
+					// it forces json (a "compact table" is meaningless); with an explicit
+					// non-json format it is simply ignored.
+					const resolvedFormat = (explicitFormat ?? (compact ? "json" : resolveDefaultFormat())) as OutputFormat;
+
 					const ctx: CommandContext = {
 						client,
 						profileName,
 						mode: "cli",
 						output: {
-							format: ((parentOpts.json ? "json" : parentOpts.output) ?? "json") as OutputFormat,
-							compact: (parentOpts.compact as boolean) ?? false,
+							format: resolvedFormat,
+							compact,
 							fields: parentOpts.fields
 								? (parentOpts.fields as string).split(",").map((f: string) => f.trim())
 								: undefined,
+							quiet: Boolean(parentOpts.quiet),
 						},
 					};
 
-					// Validate and parse input through Zod
-					const parsed = cmd.inputSchema.parse(input);
+					// Validate and parse input through Zod — convert a parse failure into
+					// a clean one-line ValidationError instead of dumping serialized JSON.
+					let parsed: unknown;
+					try {
+						parsed = cmd.inputSchema.parse(input);
+					} catch (e) {
+						throw toValidationError(e);
+					}
 					const result = await cmd.execute(parsed, ctx);
 
 					// Output (skip if result is null or command already handled output)
@@ -263,9 +307,18 @@ export function buildProgram(registry: CommandRegistry): Command {
 						// Skip stdout for streamed results (content already rendered via SSE)
 						const isStreamed = typeof result === "object" && (result as Record<string, unknown>).streamed === true;
 						if (!isStreamed) {
-							const hasGlobalFlags = ctx.output.compact || ctx.output.format !== "json" || ctx.output.fields;
+							// A command's bespoke formatOutput owns plain JSON (explicit --json,
+							// or the non-TTY default). Everything else — table/markdown/csv, or
+							// --fields/--compact projections — goes through the shared generic
+							// renderer so behavior is uniform across all commands.
+							const useGeneric =
+								Boolean(ctx.output.fields) ||
+								ctx.output.compact ||
+								ctx.output.format === "csv" ||
+								ctx.output.format === "table" ||
+								ctx.output.format === "markdown";
 							let formatted: string;
-							if (cmd.formatOutput && !hasGlobalFlags) {
+							if (cmd.formatOutput && !useGeneric) {
 								formatted = cmd.formatOutput(result, ctx.output.format);
 							} else {
 								formatted = formatOutput(result, {

--- a/src/adapters/cli.ts
+++ b/src/adapters/cli.ts
@@ -26,6 +26,7 @@ import {
 	ValidationError,
 } from "../lib/errors.js";
 import { formatOutput, type OutputFormat } from "../lib/output.js";
+import { readStdin } from "../lib/stdin.js";
 import { resolveDefaultFormat } from "../lib/tty.js";
 
 /** Output formats accepted by --output / --json / --md. */
@@ -197,18 +198,29 @@ export function buildProgram(registry: CommandRegistry): Command {
 
 			const opts = zodToCommanderOptions(cmd.inputSchema);
 
+			// Append a stdin hint to the field that accepts "-" (CLI help only; the
+			// Zod description stays clean for the MCP JSON schema).
+			const fieldForFlags = (flags: string): string => {
+				const token = flags.trim().split(/\s+/)[0];
+				return kebabToCamel(token.replace(/^--/, "").replace(/[<>[\]]/g, ""));
+			};
+			const describeOpt = (opt: CommanderOption): string =>
+				cmd.stdinField && fieldForFlags(opt.flags) === cmd.stdinField
+					? `${opt.description} (use '-' to read from stdin)`
+					: opt.description;
+
 			// Add positional arguments first, then options
 			for (const opt of opts) {
 				if (opt.isArgument) {
-					sub.argument(opt.flags, opt.description);
+					sub.argument(opt.flags, describeOpt(opt));
 				}
 			}
 			for (const opt of opts) {
 				if (opt.isArgument) continue;
 				if (opt.choices) {
-					sub.option(opt.flags, opt.description, opt.defaultValue as string);
+					sub.option(opt.flags, describeOpt(opt), opt.defaultValue as string);
 				} else {
-					sub.option(opt.flags, opt.description, opt.defaultValue as string | boolean | undefined);
+					sub.option(opt.flags, describeOpt(opt), opt.defaultValue as string | boolean | undefined);
 				}
 			}
 
@@ -291,6 +303,21 @@ export function buildProgram(registry: CommandRegistry): Command {
 							quiet: Boolean(parentOpts.quiet),
 						},
 					};
+
+					// Opt-in stdin: a value of "-" on the command's declared stdinField
+					// means "read it from stdin", so secrets/large bodies need not sit on
+					// the command line. CLI-only (the MCP adapter never enters here).
+					if (cmd.stdinField && input[cmd.stdinField] === "-") {
+						if (process.stdin.isTTY) {
+							throw new ValidationError(
+								`'-' reads ${camelToKebab(cmd.stdinField)} from stdin, but stdin is a terminal.`,
+								"Pipe data in, e.g.:  cat file.txt | elnora ... -",
+							);
+						}
+						// Strip a single trailing newline (the usual shell/echo artifact);
+						// keep internal newlines and leading whitespace for multi-line bodies.
+						input[cmd.stdinField] = (await readStdin()).replace(/\r?\n$/, "");
+					}
 
 					// Validate and parse input through Zod — convert a parse failure into
 					// a clean one-line ValidationError instead of dumping serialized JSON.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@
 
 import { buildProgram } from "./adapters/cli.js";
 import { addCompletionCommand } from "./commands/completion.js";
+import { addConfigCommand } from "./commands/config.js";
 import { addDoctorCommand } from "./commands/doctor.js";
 import { addMcpCommands } from "./commands/mcp/serve.js";
 import { addOpenCommand } from "./commands/open.js";
@@ -47,6 +48,14 @@ process.on("unhandledRejection", (reason) => {
 
 const registry = buildRegistry();
 
+// Honor cross-cutting global flags before Commander parses, so they also apply
+// to the background update notice (registered below) and any color resolution.
+// --no-color maps to the NO_COLOR convention; --quiet silences the update nag.
+if (process.argv.includes("--no-color") && !process.env.NO_COLOR) {
+	process.env.NO_COLOR = "1";
+}
+const quiet = process.argv.includes("--quiet");
+
 // ---------------------------------------------------------------------------
 // Build program and add standalone commands
 // ---------------------------------------------------------------------------
@@ -57,12 +66,13 @@ const program = buildProgram(registry);
 addMcpCommands(program, registry);
 addDoctorCommand(program);
 addWhoamiCommand(program);
+addConfigCommand(program);
 addOpenCommand(program);
 addSetupCommand(program);
 addUpdateCommand(program);
 addCompletionCommand(program);
 
-// Background update check (non-blocking, 24h cache)
-registerUpdateCheck();
+// Background update check (non-blocking, 24h cache). Suppressed by --quiet.
+registerUpdateCheck(quiet);
 
 program.parseAsync(process.argv);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import { addSetupCommand } from "./commands/setup.js";
 import { addUpdateCommand } from "./commands/update.js";
 import { addWhoamiCommand } from "./commands/whoami.js";
 import { buildRegistry } from "./core/build-registry.js";
+import { maybePrintBanner } from "./lib/banner.js";
 import { formatErrorForHuman, formatErrorPayload, getExitCode } from "./lib/errors.js";
 import { registerUpdateCheck } from "./lib/update-check.js";
 
@@ -55,6 +56,10 @@ if (process.argv.includes("--no-color") && !process.env.NO_COLOR) {
 	process.env.NO_COLOR = "1";
 }
 const quiet = process.argv.includes("--quiet");
+
+// Branded banner on bare `elnora` / top-level --help (TTY only; never piped, in
+// CI, with --quiet, or before a subcommand). Goes to stderr so stdout stays clean.
+maybePrintBanner(process.argv);
 
 // ---------------------------------------------------------------------------
 // Build program and add standalone commands

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -5,10 +5,12 @@ import { AuthError, ValidationError } from "../../lib/errors.js";
 import type { OutputFormat } from "../../lib/output.js";
 import { getApiKey, listProfileNames, saveProfile, validateProfileName } from "../../lib/profiles.js";
 import { promptSecret } from "../../lib/prompt.js";
+import { readStdin } from "../../lib/stdin.js";
 import { isTTY } from "../../lib/tty.js";
 
 const inputSchema = z.object({
 	apiKey: z.string().optional().describe("Elnora API key (elnora_live_...)"),
+	apiKeyStdin: z.boolean().default(false).describe("Read the API key from stdin instead of an argument"),
 	profile: z.string().default("default").describe("Profile name to save key under"),
 });
 
@@ -26,6 +28,41 @@ export const authLogin: ElnoraCommand<Input> = {
 		let apiKey = input.apiKey;
 		const profileName = input.profile;
 		validateProfileName(profileName);
+
+		// --api-key and --api-key-stdin are mutually exclusive.
+		if (input.apiKeyStdin && apiKey) {
+			throw new ValidationError(
+				"Cannot use --api-key and --api-key-stdin together. Choose one.",
+				'Pipe the key:  printf %s "$ELNORA_API_KEY" | elnora auth login --api-key-stdin',
+			);
+		}
+
+		// --api-key-stdin: read the key from piped stdin so it never appears in
+		// the process command line (where `ps` / Win32_Process can read it).
+		if (input.apiKeyStdin) {
+			// stdin.isTTY (not lib/tty.isTTY, which checks stdout): nothing piped → would hang.
+			if (process.stdin.isTTY) {
+				throw new ValidationError(
+					"--api-key-stdin requires the key on stdin, but stdin is a terminal.",
+					'Example:  printf %s "$ELNORA_API_KEY" | elnora auth login --api-key-stdin',
+				);
+			}
+			const piped = (await readStdin()).trim();
+			if (!piped) {
+				throw new ValidationError(
+					"No API key received on stdin.",
+					'Pipe a key:  printf %s "$ELNORA_API_KEY" | elnora auth login --api-key-stdin',
+				);
+			}
+			apiKey = piped;
+		}
+
+		// Honor ELNORA_API_KEY / ELNORA_MCP_API_KEY when no key was supplied via
+		// flag or stdin — enables non-interactive `ELNORA_API_KEY=... elnora auth login`.
+		if (!apiKey) {
+			const envKey = process.env.ELNORA_API_KEY ?? process.env.ELNORA_MCP_API_KEY;
+			if (envKey) apiKey = envKey;
+		}
 
 		const existing = listProfileNames();
 		const profileExists = existing.includes(profileName);
@@ -82,7 +119,7 @@ export const authLogin: ElnoraCommand<Input> = {
 
 		if (!apiKey) {
 			throw new ValidationError(
-				"API key is required. Use --api-key flag or run interactively in a terminal.",
+				"API key is required. Pass --api-key, pipe it with --api-key-stdin, set ELNORA_API_KEY, or run interactively in a terminal.",
 				"Get your API key from: https://platform.elnora.ai > Settings > API Keys",
 			);
 		}
@@ -115,6 +152,11 @@ export const authLogin: ElnoraCommand<Input> = {
 			if (isTTY()) {
 				process.stderr.write(` Done! ${projectCount} project${projectCount !== 1 ? "s" : ""} accessible.\n`);
 				process.stderr.write(`  Saved to profile "${profileName}" at ${configPath}\n\n`);
+				// Guidance goes to stderr so stdout stays clean, machine-readable data.
+				process.stderr.write("  Next steps:\n");
+				process.stderr.write("    elnora projects list                         See your projects\n");
+				process.stderr.write("    elnora tasks create --project <ID> --stream  Start a conversation\n");
+				process.stderr.write("    elnora doctor                                Verify your setup\n\n");
 			}
 
 			return { profile: profileName, verified: true, configPath };
@@ -134,15 +176,8 @@ export const authLogin: ElnoraCommand<Input> = {
 	formatOutput(output: unknown, format: OutputFormat): string {
 		const data = output as { profile?: string };
 		if (format === "compact") return data.profile ?? JSON.stringify(output);
-
-		const lines = [
-			`✓ Authenticated! API key saved to profile "${data.profile}".`,
-			"",
-			"Next steps:",
-			"  elnora projects list                         See your projects",
-			"  elnora tasks create --project <ID> --stream  Start a conversation",
-			"  elnora doctor                                Verify your setup",
-		];
-		return lines.join("\n");
+		// Machine-readable result on stdout; the human "Next steps" guidance is
+		// written to stderr during execute so it survives any output format.
+		return JSON.stringify(output, null, 2);
 	},
 };

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,55 @@
+import type { Command } from "commander";
+import { AI_SERVER_URL, BASE_URL, MCP_URL } from "../lib/config.js";
+import { loadProfiles } from "../lib/profiles.js";
+
+/**
+ * Report WHERE the active API key would come from — never the key value.
+ * Mirrors resolveApiKey precedence (env over profile) without throwing when
+ * unauthenticated, so `config show` always succeeds offline.
+ */
+function resolveKeySource(profileName: string): string {
+	// Mirror resolveApiKey's `??` (set-vs-unset) precedence so the reported source
+	// matches what the CLI will actually use — even for a set-but-empty env var.
+	if (process.env.ELNORA_API_KEY !== undefined) return "env:ELNORA_API_KEY";
+	if (process.env.ELNORA_MCP_API_KEY !== undefined) return "env:ELNORA_MCP_API_KEY";
+	const profiles = loadProfiles();
+	if (profiles[profileName]?.api_key) return `profile:${profileName}`;
+	return "none";
+}
+
+/**
+ * `elnora config show` — print the resolved endpoints, active profile, and key
+ * source in a stable, greppable form. Purely local: no network, no auth, no
+ * mutation, always exit 0. Standalone (like doctor/whoami) so it works without
+ * an API key and is never exposed as an MCP tool.
+ */
+export function addConfigCommand(program: Command): void {
+	const config = program.command("config").description("Inspect Elnora CLI configuration");
+	config
+		.command("show")
+		.description("Show resolved CLI configuration (endpoints, active profile, key source)")
+		.action(() => {
+			const parentOpts = program.opts();
+			const profileName = (parentOpts.profile as string) ?? "default";
+			const data = {
+				base_url: BASE_URL,
+				ai_server_url: AI_SERVER_URL,
+				mcp_url: MCP_URL,
+				active_profile: profileName,
+				key_source: resolveKeySource(profileName),
+			};
+
+			// JSON when forced or when piped/redirected (non-TTY), matching the rest
+			// of the CLI; stable key=value for interactive terminals.
+			if (parentOpts.json || !process.stdout.isTTY) {
+				console.log(JSON.stringify(data, null, 2));
+				return;
+			}
+			// Stable key=value, fixed order — grep/cut friendly.
+			console.log(`base_url=${data.base_url}`);
+			console.log(`ai_server_url=${data.ai_server_url}`);
+			console.log(`mcp_url=${data.mcp_url}`);
+			console.log(`active_profile=${data.active_profile}`);
+			console.log(`key_source=${data.key_source}`);
+		});
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5,6 +5,7 @@ import type { Command } from "commander";
 import pc from "picocolors";
 import { ElnoraApiClient } from "../lib/client.js";
 import { AI_SERVER_URL, MCP_URL, VERSION } from "../lib/config.js";
+import { detectAllInstalls, uninstallCommandFor } from "../lib/install-discovery.js";
 import { PROFILES_FILE, resolveApiKey } from "../lib/profiles.js";
 import { CLAUDE_DIR, CLAUDE_SETTINGS_FILE, MARKETPLACE_NAME, PLUGIN_ID } from "../lib/setup/common.js";
 import { isColorEnabled } from "../lib/tty.js";
@@ -116,6 +117,31 @@ function checkPathConfigured(): CheckResult {
 	return {
 		status: "warn",
 		msg: "PATH configured       standard install dirs not in PATH (OK if installed via npm/brew)",
+	};
+}
+
+function checkShadowInstalls(): CheckResult {
+	const installs = detectAllInstalls();
+	const active = installs.find((i) => i.active);
+	// If we can't identify the active install on PATH (e.g. running from a dev
+	// build / non-PATH location), we can't reliably call others "shadows" — skip
+	// rather than emit a misleading warning.
+	if (!active) {
+		return { status: "skip", msg: "Shadow installs        (running from a non-PATH/dev build)" };
+	}
+	const shadows = installs.filter((i) => !i.active && i.source !== "dev");
+	if (shadows.length === 0) {
+		return { status: "pass", msg: `No shadow installs     ${active.path} (${active.source})` };
+	}
+	// Shadow installs make `elnora` ambiguous and cause stale-version confusion,
+	// but the CLI still runs — warn (non-fatal), don't fail.
+	const lines = shadows.map((s) => {
+		const cmd = uninstallCommandFor(s);
+		return `      shadow: ${s.path} (${s.source})${cmd ? ` — ${cmd}` : " — remove manually"}`;
+	});
+	return {
+		status: "warn",
+		msg: `Shadow installs        ${shadows.length} other elnora on PATH (active: ${active.path} [${active.source}])\n${lines.join("\n")}`,
 	};
 }
 
@@ -374,6 +400,7 @@ export function addDoctorCommand(program: Command): void {
 				await runCheck(() => checkConfigPermissions()),
 				await runCheck(() => checkAiServerReachable()),
 				await runCheck(() => checkPathConfigured()),
+				await runCheck(() => checkShadowInstalls()),
 			];
 			for (const r of cliChecks) {
 				console.error(render(r));

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4,7 +4,7 @@ import { delimiter, join } from "node:path";
 import type { Command } from "commander";
 import pc from "picocolors";
 import { ElnoraApiClient } from "../lib/client.js";
-import { AI_SERVER_URL, VERSION } from "../lib/config.js";
+import { AI_SERVER_URL, MCP_URL, VERSION } from "../lib/config.js";
 import { PROFILES_FILE, resolveApiKey } from "../lib/profiles.js";
 import { CLAUDE_DIR, CLAUDE_SETTINGS_FILE, MARKETPLACE_NAME, PLUGIN_ID } from "../lib/setup/common.js";
 import { isColorEnabled } from "../lib/tty.js";
@@ -287,21 +287,22 @@ function checkPluginVersion(): CheckResult {
 
 async function checkMcpReachable(): Promise<CheckResult> {
 	const start = Date.now();
+	const mcpHost = new URL(MCP_URL).hostname;
 	try {
-		const res = await fetch("https://mcp.elnora.ai/mcp", {
+		const res = await fetch(MCP_URL, {
 			method: "HEAD",
 			signal: AbortSignal.timeout(5000),
 		});
 		const ms = Date.now() - start;
 		// 401 is expected (not authenticated) — means server is up. Any 2xx-4xx is "server up".
 		if (res.status < 500) {
-			return { status: "pass", msg: `Server reachable       mcp.elnora.ai (${res.status}, ${ms}ms)` };
+			return { status: "pass", msg: `Server reachable       ${mcpHost} (${res.status}, ${ms}ms)` };
 		}
-		return { status: "fail", msg: `Server unreachable     mcp.elnora.ai (HTTP ${res.status})` };
+		return { status: "fail", msg: `Server unreachable     ${mcpHost} (HTTP ${res.status})` };
 	} catch (e) {
 		return {
 			status: "fail",
-			msg: `Server unreachable     mcp.elnora.ai (${e instanceof Error ? e.message : "network error"})`,
+			msg: `Server unreachable     ${mcpHost} (${e instanceof Error ? e.message : "network error"})`,
 		};
 	}
 }

--- a/src/commands/feedback/submit.ts
+++ b/src/commands/feedback/submit.ts
@@ -13,6 +13,7 @@ export const feedbackSubmit: ElnoraCommand<Input> = {
 	name: "feedback.submit",
 	group: "feedback",
 	description: "Submit feedback",
+	stdinField: "description",
 	inputSchema,
 	outputSchema: z.any(),
 

--- a/src/commands/files/create-version.ts
+++ b/src/commands/files/create-version.ts
@@ -13,6 +13,7 @@ export const filesCreateVersion: ElnoraCommand<Input> = {
 	name: "files.createVersion",
 	group: "files",
 	description: "Create a new version of a file",
+	stdinField: "content",
 	inputSchema,
 	outputSchema: z.any(),
 

--- a/src/commands/protocols/generate.ts
+++ b/src/commands/protocols/generate.ts
@@ -19,6 +19,7 @@ export const protocolsGenerate: ElnoraCommand<Input> = {
 	name: "protocols.generate",
 	group: "protocols",
 	description: "Generate a bioprotocol — creates a task and sends the description in one call",
+	stdinField: "description",
 	inputSchema,
 	outputSchema: z.any(),
 	annotations: { mcpScopes: ["tasks:write", "messages:write"] },

--- a/src/commands/search/all.ts
+++ b/src/commands/search/all.ts
@@ -14,6 +14,7 @@ export const searchAll: ElnoraCommand<Input> = {
 	name: "search.all",
 	group: "search",
 	description: "Search across all entities",
+	stdinField: "query",
 	inputSchema,
 	outputSchema: z.any(),
 	annotations: { readOnlyHint: true },

--- a/src/commands/search/file-content.ts
+++ b/src/commands/search/file-content.ts
@@ -15,6 +15,7 @@ export const searchFileContent: ElnoraCommand<Input> = {
 	name: "search.fileContent",
 	group: "search",
 	description: "Search within file contents",
+	stdinField: "query",
 	inputSchema,
 	outputSchema: z.any(),
 	annotations: { readOnlyHint: true },

--- a/src/commands/search/files.ts
+++ b/src/commands/search/files.ts
@@ -14,6 +14,7 @@ export const searchFiles: ElnoraCommand<Input> = {
 	name: "search.files",
 	group: "search",
 	description: "Search files by query",
+	stdinField: "query",
 	inputSchema,
 	outputSchema: z.any(),
 	annotations: { readOnlyHint: true },

--- a/src/commands/search/tasks.ts
+++ b/src/commands/search/tasks.ts
@@ -14,6 +14,7 @@ export const searchTasks: ElnoraCommand<Input> = {
 	name: "search.tasks",
 	group: "search",
 	description: "Search tasks by query",
+	stdinField: "query",
 	inputSchema,
 	outputSchema: z.any(),
 	annotations: { readOnlyHint: true },

--- a/src/commands/tasks/create.ts
+++ b/src/commands/tasks/create.ts
@@ -20,6 +20,7 @@ export const tasksCreate: ElnoraCommand<Input> = {
 	name: "tasks.create",
 	group: "tasks",
 	description: "Create a new task in a project",
+	stdinField: "message",
 	inputSchema,
 	outputSchema: z.any(),
 

--- a/src/commands/tasks/create.ts
+++ b/src/commands/tasks/create.ts
@@ -59,7 +59,7 @@ export const tasksCreate: ElnoraCommand<Input> = {
 		if (input.stream) {
 			try {
 				const apiKey = resolveApiKey(ctx.profileName);
-				const renderer = new StreamRenderer();
+				const renderer = new StreamRenderer({ quiet: ctx.output.quiet });
 				for await (const event of streamTask(taskId, apiKey)) {
 					renderer.renderEvent(event);
 				}

--- a/src/commands/tasks/send.ts
+++ b/src/commands/tasks/send.ts
@@ -75,7 +75,7 @@ export const tasksSend: ElnoraCommand<Input> = {
 		if (input.stream) {
 			try {
 				const apiKey = resolveApiKey(ctx.profileName);
-				const renderer = new StreamRenderer();
+				const renderer = new StreamRenderer({ quiet: ctx.output.quiet });
 				for await (const event of streamTask(input.taskId, apiKey)) {
 					renderer.renderEvent(event);
 				}

--- a/src/commands/tasks/send.ts
+++ b/src/commands/tasks/send.ts
@@ -22,6 +22,7 @@ export const tasksSend: ElnoraCommand<Input> = {
 	name: "tasks.send",
 	group: "tasks",
 	description: "Send a message to a task",
+	stdinField: "message",
 	inputSchema,
 	outputSchema: z.any(),
 

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -28,6 +28,8 @@ export interface CommandContext {
 		format: OutputFormat;
 		compact: boolean;
 		fields?: string[];
+		/** Suppress non-essential chrome (spinners, progress) on stderr. */
+		quiet?: boolean;
 	};
 }
 

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -49,6 +49,12 @@ export interface ElnoraCommand<I = unknown, O = unknown> {
 	/** Zod schema for output — used for type safety + output formatting */
 	outputSchema: ZodType<O>;
 
+	/**
+	 * Optional: the input field whose value of "-" means "read this from stdin"
+	 * (CLI only). Enables e.g. `cat protocol.md | elnora tasks send <id> --message -`.
+	 */
+	stdinField?: string;
+
 	/** Execute the command */
 	execute(input: I, ctx: CommandContext): Promise<O>;
 

--- a/src/lib/banner.ts
+++ b/src/lib/banner.ts
@@ -1,0 +1,31 @@
+/** Branded startup banner shown on bare `elnora` (and top-level --help). */
+
+import pc from "picocolors";
+import { VERSION } from "./config.js";
+import { isColorEnabled } from "./tty.js";
+
+/** The wordmark for the current color state. Pure — testable without streams. */
+export function renderBanner(): string {
+	const label = "ELNORA  ·  AI Platform CLI";
+	const inner = `  ${label}  `;
+	const bar = "─".repeat(inner.length);
+	const box = [`┌${bar}┐`, `│${inner}│`, `└${bar}┘`].join("\n");
+	const head = isColorEnabled() ? pc.cyan(box) : box;
+	return `${head}\nv${VERSION}`;
+}
+
+/**
+ * Print the banner to stderr for bare `elnora` or top-level `--help` only.
+ * Skipped when piped/redirected, in CI, with --quiet, on --version, and for any
+ * subcommand — so machine output and the MCP stdio transport stay clean.
+ */
+export function maybePrintBanner(argv: string[]): void {
+	if (process.env.CI || process.env.GITHUB_ACTIONS) return;
+	if (!process.stderr.isTTY) return;
+	const args = argv.slice(2);
+	if (args.includes("--quiet")) return;
+	const isBare = args.length === 0;
+	const isTopHelp = args.length === 1 && (args[0] === "--help" || args[0] === "-h");
+	if (!isBare && !isTopHelp) return;
+	process.stderr.write(`${renderBanner()}\n\n`);
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,6 +16,8 @@ export const VERSION: string =
 export const PRODUCTION_BASE_URL = "https://platform.elnora.ai/api/v1";
 export const BASE_URL = process.env.ELNORA_API_URL ?? PRODUCTION_BASE_URL;
 export const AI_SERVER_URL = process.env.ELNORA_AI_SERVER_URL ?? "https://platform.elnora.ai/ai-server";
+export const PRODUCTION_MCP_URL = "https://mcp.elnora.ai/mcp";
+export const MCP_URL = process.env.ELNORA_MCP_URL ?? PRODUCTION_MCP_URL;
 
 export const ENDPOINTS: Record<string, string> = {
 	// Projects

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -9,6 +9,8 @@
  *   Warning: JSON to stderr, exit 0
  */
 
+import { z } from "zod";
+
 // ---------------------------------------------------------------------------
 // Error hierarchy
 // ---------------------------------------------------------------------------
@@ -198,4 +200,28 @@ export function formatErrorForHuman(err: Error): string {
 	}
 
 	return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Zod → ValidationError
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a thrown error into a clean ValidationError when it is a Zod parse
+ * failure, so a mistyped argument surfaces as e.g. "projectId: Invalid UUID"
+ * (exit code 2) instead of a wall of serialized ZodError JSON. Non-Zod errors
+ * are returned unchanged.
+ */
+export function toValidationError(err: unknown): Error {
+	if (err instanceof z.ZodError) {
+		const first = err.issues[0];
+		const field = first?.path.length ? first.path.join(".") : "input";
+		const message = first?.message ?? "Invalid input";
+		const more = err.issues.length > 1 ? ` (+${err.issues.length - 1} more)` : "";
+		return new ValidationError(
+			`${field}: ${message}${more}`,
+			"Run the command with --help to see the expected inputs.",
+		);
+	}
+	return err instanceof Error ? err : new Error(String(err));
 }

--- a/src/lib/install-discovery.ts
+++ b/src/lib/install-discovery.ts
@@ -1,0 +1,156 @@
+/**
+ * Discover every `elnora` on PATH and classify each install, so `elnora doctor`
+ * can flag shadow installs (a stale copy earlier on PATH is the classic "why
+ * didn't my upgrade take effect" bug). Pure filesystem scan — no child processes.
+ */
+
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { posix, win32 } from "node:path";
+
+type PathModule = typeof posix;
+
+export type InstallSource = "npm" | "homebrew" | "binary" | "dev" | "unknown";
+
+export interface FoundInstall {
+	/** The on-PATH entry the shell would resolve. */
+	path: string;
+	/** Symlinks/shims resolved (used for dedupe + active match). */
+	realPath: string;
+	source: InstallSource;
+	/** The $PATH directory it was found in. */
+	pathDir: string;
+	/** Whether this is the install running right now. */
+	active: boolean;
+}
+
+export interface DiscoverEnv {
+	pathVar: string;
+	pathExt: string;
+	platform: NodeJS.Platform;
+	home: string;
+	execPath: string;
+	argv1: string;
+	installDirOverride?: string;
+}
+
+const norm = (p: string): string => p.replace(/\\/g, "/").toLowerCase();
+
+function safeRealPath(p: string): string {
+	try {
+		return realpathSync(p);
+	} catch {
+		return p;
+	}
+}
+
+function candidateNames(platform: NodeJS.Platform, pathExt: string): string[] {
+	if (platform !== "win32") return ["elnora"];
+	// PATHEXT variants first (the shell resolves these), bare `elnora` (sh shim) last.
+	const names: string[] = [];
+	for (const raw of pathExt.split(";")) {
+		const ext = raw.trim().toLowerCase();
+		if (ext) names.push(`elnora${ext.startsWith(".") ? ext : `.${ext}`}`);
+	}
+	names.push("elnora");
+	return [...new Set(names)];
+}
+
+/** The npm prefix dir of a path under a node_modules tree, else undefined. */
+function npmPrefix(p: string): string | undefined {
+	const n = norm(p);
+	const idx = n.indexOf("/node_modules/");
+	return idx > 0 ? n.slice(0, idx) : undefined;
+}
+
+function classify(realPath: string, home: string, pathMod: PathModule, installDirOverride?: string): InstallSource {
+	const p = norm(realPath);
+	if (p.includes("/node_modules/")) return "npm";
+	// Windows global npm writes shims (elnora / .cmd / .ps1) directly in the npm
+	// prefix dir (e.g. %AppData%\npm\elnora.cmd) — not under node_modules.
+	if (/\/npm\/elnora[^/]*$/.test(p)) return "npm";
+	if (p.includes("/cellar/") || p.includes("/homebrew/")) return "homebrew";
+	if (p.endsWith(".ts") || p.endsWith(".tsx") || p.includes("/tsx/")) return "dev";
+	const binDirs = [pathMod.join(home, ".elnora", "bin"), pathMod.join(home, ".local", "bin"), installDirOverride]
+		.filter((d): d is string => Boolean(d))
+		.map(norm);
+	if (binDirs.some((d) => p === d || p.startsWith(`${d}/`))) return "binary";
+	return "unknown";
+}
+
+/** Pure core — environment injected so it's testable without globals or spawns. */
+export function discoverInstalls(env: DiscoverEnv): FoundInstall[] {
+	// Use the path semantics of the target platform (not the runtime one) so the
+	// PATH delimiter and joins are correct and the function is cross-platform testable.
+	const pathMod = env.platform === "win32" ? win32 : posix;
+	const dirs = env.pathVar.split(pathMod.delimiter).filter(Boolean);
+	const names = candidateNames(env.platform, env.pathExt);
+
+	// Real paths of the currently-running install (packaged binary → execPath;
+	// npm/tsx → argv1 is the JS/TS entry the shim points at).
+	const activeReals = new Set<string>();
+	for (const candidate of [env.execPath, env.argv1]) {
+		if (candidate) activeReals.add(norm(safeRealPath(candidate)));
+	}
+	// Windows npm shims aren't symlinks, so realpath can't match them. Match the
+	// shim's directory against the npm prefix of the running cli.js instead.
+	const activePrefix = npmPrefix(env.argv1) ?? npmPrefix(safeRealPath(env.argv1));
+
+	const byReal = new Map<string, FoundInstall>();
+	for (const dir of dirs) {
+		// One logical install per directory: Windows npm writes elnora + .cmd +
+		// .ps1 into a single dir; a packaged install writes one elnora[.exe]. Take
+		// the first candidate the shell would resolve (PATHEXT order) and stop.
+		let full: string | undefined;
+		for (const name of names) {
+			const candidate = pathMod.join(dir, name);
+			try {
+				if (existsSync(candidate) && statSync(candidate).isFile()) {
+					full = candidate;
+					break;
+				}
+			} catch {
+				/* unreadable — skip */
+			}
+		}
+		if (!full) continue;
+		const realPath = safeRealPath(full);
+		const key = norm(realPath);
+		if (byReal.has(key)) continue; // dedupe symlinks/duplicates across dirs (first wins)
+		const active = activeReals.has(key) || (activePrefix !== undefined && norm(dir) === activePrefix);
+		byReal.set(key, {
+			path: full,
+			realPath,
+			pathDir: dir,
+			source: classify(realPath, env.home, pathMod, env.installDirOverride),
+			active,
+		});
+	}
+	return [...byReal.values()];
+}
+
+export function detectAllInstalls(): FoundInstall[] {
+	return discoverInstalls({
+		pathVar: process.env.PATH ?? "",
+		pathExt: process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD",
+		platform: process.platform,
+		home: homedir(),
+		execPath: process.execPath,
+		argv1: process.argv[1] ?? "",
+		installDirOverride: process.env.ELNORA_INSTALL_DIR,
+	});
+}
+
+/** The command to remove a given install, or null when removal isn't advised (dev). */
+export function uninstallCommandFor(install: FoundInstall): string | null {
+	switch (install.source) {
+		case "npm":
+			return "npm uninstall -g @elnora-ai/cli";
+		case "homebrew":
+			return "brew uninstall elnora";
+		case "dev":
+			return null;
+		default:
+			return process.platform === "win32" ? `Remove-Item "${install.path}"` : `rm "${install.path}"`;
+	}
+}

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -5,6 +5,7 @@
  */
 
 import { scrubData } from "./errors.js";
+import { hasControlChar, hyperlink } from "./tty.js";
 
 export type OutputFormat = "json" | "csv" | "compact" | "table" | "markdown";
 
@@ -99,6 +100,23 @@ function clipCell(value: unknown, max = MAX_CELL_WIDTH): string {
 	return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
 }
 
+const URL_RE = /^https?:\/\/\S+$/;
+
+/**
+ * Make a URL value clickable in the key/value table view only. NOT for the
+ * columnar list view: the OSC 8 escapes have zero display width but real string
+ * length, which would break the padEnd column math. hyperlink() self-gates on
+ * color/TTY, so piped output stays plain. Reject control bytes so a malicious URL
+ * value can't sneak an escape sequence past hyperlink()'s sanitizer.
+ */
+function linkifyCell(value: unknown): string {
+	const text = clipCell(value);
+	if (typeof value === "string" && URL_RE.test(value) && !hasControlChar(value)) {
+		return hyperlink(value, text);
+	}
+	return text;
+}
+
 /** True when the data is a collection (array, or an object with an `items` array). */
 function isListShape(data: unknown): boolean {
 	if (Array.isArray(data)) return true;
@@ -151,7 +169,8 @@ function toTable(data: unknown): string {
 		const entries = Object.entries(data as Record<string, unknown>);
 		if (entries.length === 0) return "(empty)";
 		const keyWidth = Math.max(...entries.map(([k]) => k.length));
-		return entries.map(([k, v]) => `${k.padEnd(keyWidth)}  ${clipCell(v)}`).join("\n");
+		// Only the key is padded; the value may carry zero-width link escapes safely.
+		return entries.map(([k, v]) => `${k.padEnd(keyWidth)}  ${linkifyCell(v)}`).join("\n");
 	}
 
 	const rows = normalizedRows(data);

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -6,7 +6,7 @@
 
 import { scrubData } from "./errors.js";
 
-export type OutputFormat = "json" | "csv" | "compact" | "table";
+export type OutputFormat = "json" | "csv" | "compact" | "table" | "markdown";
 
 export interface OutputOptions {
 	format: OutputFormat;
@@ -72,20 +72,155 @@ function toCsv(rows: Record<string, unknown>[]): string {
 	return lines.join("\n");
 }
 
+// ---------------------------------------------------------------------------
+// Human-readable renderers (table = the interactive/TTY default; markdown for
+// agent/chat consumption). These run AFTER scrubData + filterFields, so secret
+// scrubbing and field selection apply uniformly across every format.
+// ---------------------------------------------------------------------------
+
+const MAX_CELL_WIDTH = 120;
+
+/** Render a cell value as a single-line string (objects → compact JSON). */
+function cellString(value: unknown): string {
+	if (value === null || value === undefined) return "";
+	if (typeof value === "object") {
+		try {
+			return JSON.stringify(value);
+		} catch {
+			return String(value);
+		}
+	}
+	return String(value);
+}
+
+/** Collapse newlines and clip overly long cells so terminal tables stay readable. */
+function clipCell(value: unknown, max = MAX_CELL_WIDTH): string {
+	const oneLine = cellString(value).replace(/\r?\n/g, " ");
+	return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
+}
+
+/** True when the data is a collection (array, or an object with an `items` array). */
+function isListShape(data: unknown): boolean {
+	if (Array.isArray(data)) return true;
+	if (typeof data === "object" && data !== null) {
+		const obj = data as Record<string, unknown>;
+		return "items" in obj && Array.isArray(obj.items);
+	}
+	return false;
+}
+
+/** Normalize rows so scalar elements still render as a single `value` column. */
+function normalizedRows(data: unknown): Record<string, unknown>[] {
+	return toRows(data).map((r) => (r !== null && typeof r === "object" && !Array.isArray(r) ? r : { value: r }));
+}
+
+function unionKeys(rows: Record<string, unknown>[]): string[] {
+	const keys: string[] = [];
+	const seen = new Set<string>();
+	for (const row of rows) {
+		for (const k of Object.keys(row)) {
+			if (!seen.has(k)) {
+				keys.push(k);
+				seen.add(k);
+			}
+		}
+	}
+	return keys;
+}
+
+/**
+ * Scalar sibling fields beside an `items` array (page, totalCount, nextCursor…).
+ * Surfaced as a footer so the human formats don't hide pagination context.
+ */
+function listMeta(data: unknown): [string, unknown][] {
+	if (data !== null && typeof data === "object" && !Array.isArray(data)) {
+		const obj = data as Record<string, unknown>;
+		if (Array.isArray(obj.items)) {
+			return Object.entries(obj).filter(([k, v]) => k !== "items" && (v === null || typeof v !== "object"));
+		}
+	}
+	return [];
+}
+
+/** Aligned plain-text table (lists) or key/value block (single object). */
+function toTable(data: unknown): string {
+	// Raw text passthrough (e.g. file content) — never box terminal-ready text.
+	if (typeof data === "string") return data;
+
+	if (!isListShape(data) && typeof data === "object" && data !== null) {
+		const entries = Object.entries(data as Record<string, unknown>);
+		if (entries.length === 0) return "(empty)";
+		const keyWidth = Math.max(...entries.map(([k]) => k.length));
+		return entries.map(([k, v]) => `${k.padEnd(keyWidth)}  ${clipCell(v)}`).join("\n");
+	}
+
+	const rows = normalizedRows(data);
+	if (rows.length === 0) return "No results.";
+	const keys = unionKeys(rows);
+	if (keys.length === 0) return "No results.";
+	const widths = keys.map((k) => Math.max(k.length, ...rows.map((r) => clipCell(r[k]).length)));
+	const renderRow = (vals: string[]) =>
+		vals
+			.map((v, i) => v.padEnd(widths[i]))
+			.join("  ")
+			.replace(/\s+$/, "");
+	const header = renderRow(keys);
+	const sep = widths.map((w) => "-".repeat(w)).join("  ");
+	const body = rows.map((r) => renderRow(keys.map((k) => clipCell(r[k]))));
+	const table = [header, sep, ...body].join("\n");
+	const meta = listMeta(data);
+	return meta.length === 0 ? table : `${table}\n\n${meta.map(([k, v]) => `${k}=${clipCell(v)}`).join("  ")}`;
+}
+
+/** Escape a value for a GitHub-flavored markdown table cell. */
+function mdCell(value: unknown): string {
+	// Escape backslashes first, then pipes, so an input backslash can't combine
+	// with the escape we add (correct, complete escaping order).
+	return cellString(value).replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+/** GitHub-flavored markdown: pipe table for lists, headed key/value for objects. */
+function toMarkdown(data: unknown): string {
+	if (typeof data === "string") return data;
+
+	if (!isListShape(data) && typeof data === "object" && data !== null) {
+		const entries = Object.entries(data as Record<string, unknown>);
+		if (entries.length === 0) return "_(empty)_";
+		return entries.map(([k, v]) => `**${k}:** ${mdCell(v)}`).join("\n");
+	}
+
+	const rows = normalizedRows(data);
+	if (rows.length === 0) return "_No results._";
+	const keys = unionKeys(rows);
+	if (keys.length === 0) return "_No results._";
+	const head = `| ${keys.join(" | ")} |`;
+	const divider = `| ${keys.map(() => "---").join(" | ")} |`;
+	const body = rows.map((r) => `| ${keys.map((k) => mdCell(r[k])).join(" | ")} |`);
+	const table = [head, divider, ...body].join("\n");
+	const meta = listMeta(data);
+	return meta.length === 0 ? table : `${table}\n\n_${meta.map(([k, v]) => `${k}: ${mdCell(v)}`).join(", ")}_`;
+}
+
 export function formatOutput(data: unknown, options: OutputOptions): string {
-	let output = scrubData(data);
+	// A raw top-level string (e.g. file content) passes through unscrubbed, matching
+	// the bespoke/--json path — never redact a user's own file content, and keep
+	// every output format byte-identical for raw content. Objects/arrays are still
+	// recursively scrubbed for credentials.
+	let output = typeof data === "string" ? data : scrubData(data);
 
 	if (options.fields) {
 		output = filterFields(output, options.fields);
 	}
 
-	if (options.format === "csv") {
-		return toCsv(toRows(output));
+	switch (options.format) {
+		case "csv":
+			return toCsv(toRows(output));
+		case "table":
+			return toTable(output);
+		case "markdown":
+			return toMarkdown(output);
+		default:
+			// JSON (and the legacy "compact" format alias)
+			return options.compact ? JSON.stringify(output) : JSON.stringify(output, null, 2);
 	}
-
-	// JSON
-	if (options.compact) {
-		return JSON.stringify(output);
-	}
-	return JSON.stringify(output, null, 2);
 }

--- a/src/lib/stdin.ts
+++ b/src/lib/stdin.ts
@@ -1,0 +1,26 @@
+/** Read piped input from stdin. */
+
+/**
+ * Read all of stdin to a string. Resolves "" immediately when stdin is a TTY
+ * (interactive — nothing piped) so callers never hang waiting on a terminal.
+ *
+ * Callers that REQUIRE piped data should guard on `process.stdin.isTTY` first
+ * and surface a clear error (see `elnora auth login --api-key-stdin`).
+ */
+export function readStdin(): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const { stdin } = process;
+		if (stdin.isTTY) {
+			resolve("");
+			return;
+		}
+		let data = "";
+		stdin.setEncoding("utf8");
+		stdin.on("data", (chunk) => {
+			data += chunk;
+		});
+		stdin.on("end", () => resolve(data));
+		stdin.on("error", (err) => reject(err));
+		stdin.resume();
+	});
+}

--- a/src/lib/stream-renderer.ts
+++ b/src/lib/stream-renderer.ts
@@ -17,9 +17,11 @@ export class StreamRenderer {
 	private spinnerFrame = 0;
 	private currentLabel = "";
 	private useColor: boolean;
+	private quiet: boolean;
 
-	constructor() {
+	constructor(opts?: { quiet?: boolean }) {
 		this.useColor = isColorEnabled();
+		this.quiet = opts?.quiet ?? false;
 	}
 
 	renderEvent(event: StreamEvent): void {
@@ -65,6 +67,9 @@ export class StreamRenderer {
 	}
 
 	private startSpinner(label: string): void {
+		// --quiet suppresses progress chrome; tokens (stdout) and errors still show.
+		if (this.quiet) return;
+
 		this.stopSpinner();
 		this.currentLabel = label;
 		this.spinnerFrame = 0;

--- a/src/lib/tty.ts
+++ b/src/lib/tty.ts
@@ -1,11 +1,34 @@
 /** TTY detection for output mode decisions. */
 
+import type { OutputFormat } from "./output.js";
+
 export function isTTY(): boolean {
 	return Boolean(process.stdout.isTTY);
 }
 
+/**
+ * Color resolution, independent of the data format (clig.dev: resolve color and
+ * format on separate axes). Precedence: NO_COLOR (set and non-empty) > FORCE_COLOR
+ * > TERM=dumb (off) > stdout is a TTY.
+ *
+ * The global `--no-color` flag is handled in the CLI entrypoint by setting
+ * `NO_COLOR` before parse (src/cli.ts), so it flows through the NO_COLOR branch
+ * here without every call site needing to thread the flag.
+ */
 export function isColorEnabled(): boolean {
-	if (process.env.NO_COLOR !== undefined) return false;
+	// NO_COLOR: any non-empty value disables color (https://no-color.org).
+	if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== "") return false;
 	if (process.env.FORCE_COLOR !== undefined) return true;
+	if (process.env.TERM === "dumb") return false;
 	return isTTY();
+}
+
+/**
+ * The default output format when the user passes no explicit format flag:
+ * human-readable `table` in an interactive terminal, machine `json` when the
+ * output is piped/redirected (non-TTY) — so scripts and agents are unaffected.
+ * Centralized here so the rule lives in one testable place.
+ */
+export function resolveDefaultFormat(): OutputFormat {
+	return isTTY() ? "table" : "json";
 }

--- a/src/lib/tty.ts
+++ b/src/lib/tty.ts
@@ -32,3 +32,36 @@ export function isColorEnabled(): boolean {
 export function resolveDefaultFormat(): OutputFormat {
 	return isTTY() ? "table" : "json";
 }
+
+/** True if the string contains a C0 control char (0x00–0x1F) or DEL (0x7F). */
+export function hasControlChar(s: string): boolean {
+	for (let i = 0; i < s.length; i++) {
+		const c = s.charCodeAt(i);
+		if (c < 0x20 || c === 0x7f) return true;
+	}
+	return false;
+}
+
+/** Remove C0 control chars and DEL from a string. */
+function stripControlChars(s: string): string {
+	let out = "";
+	for (let i = 0; i < s.length; i++) {
+		const c = s.charCodeAt(i);
+		if (c >= 0x20 && c !== 0x7f) out += s[i];
+	}
+	return out;
+}
+
+/**
+ * Wrap text in an OSC 8 hyperlink (clickable in modern terminals). Returns the
+ * bare text when color/links are disabled (NO_COLOR, non-TTY, etc.) or the URL
+ * is empty — so escape sequences never leak into piped or machine output. The
+ * URL is stripped of control bytes (notably BEL/ESC) so a server-supplied value
+ * can't break out of the OSC 8 sequence and inject terminal escape codes.
+ */
+export function hyperlink(url: string, text: string): string {
+	if (!url || !isColorEnabled()) return text;
+	const safeUrl = stripControlChars(url);
+	if (!safeUrl) return text;
+	return `\x1b]8;;${safeUrl}\x07${text}\x1b]8;;\x07`;
+}

--- a/src/lib/update-check.ts
+++ b/src/lib/update-check.ts
@@ -19,11 +19,22 @@ const CACHE_DIR = join(homedir(), ".elnora");
 const CACHE_FILE = join(CACHE_DIR, ".update-check");
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const FETCH_TIMEOUT_MS = 3000;
-const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?$/;
 
 interface CacheEntry {
 	checkedAt: string;
 	latest: string;
+}
+
+/**
+ * Validate and canonicalize a version string from the npm registry. Returns a
+ * clean MAJOR.MINOR.PATCH rebuilt from numeric parts via Number() — so untrusted
+ * network data is never written verbatim to the cache file — or null if the value
+ * isn't a plain release version. Exported for testing.
+ */
+export function sanitizeVersion(raw: string): string | null {
+	const m = /^(\d{1,9})\.(\d{1,9})\.(\d{1,9})$/.exec(raw);
+	if (!m) return null;
+	return `${Number(m[1])}.${Number(m[2])}.${Number(m[3])}`;
 }
 
 function shouldSkipEntirely(): boolean {
@@ -83,7 +94,7 @@ export function isNewerVersion(a: string, b: string): boolean {
  * Register update check to run at process exit.
  * Cache refresh runs even in non-TTY; notification only in TTY.
  */
-export function registerUpdateCheck(): void {
+export function registerUpdateCheck(quiet = false): void {
 	if (shouldSkipEntirely()) return;
 
 	// Check cache first
@@ -91,8 +102,8 @@ export function registerUpdateCheck(): void {
 	if (cached) {
 		const elapsed = Date.now() - new Date(cached.checkedAt).getTime();
 		if (elapsed < CHECK_INTERVAL_MS) {
-			// Cache is fresh — show notice if update available
-			if (cached.latest && cached.latest !== VERSION && cached.latest !== "unknown") {
+			// Cache is fresh — show notice if update available (unless --quiet)
+			if (!quiet && cached.latest && cached.latest !== VERSION && cached.latest !== "unknown") {
 				if (isNewerVersion(cached.latest, VERSION)) {
 					showUpdateNotice(cached.latest);
 				}
@@ -113,13 +124,14 @@ export function registerUpdateCheck(): void {
 			});
 			if (!response.ok) return;
 			const data = (await response.json()) as { version?: string };
-			const latest = data.version ?? "unknown";
-
-			if (latest !== "unknown" && !SEMVER_RE.test(latest)) return;
+			// Sanitize the registry value before it touches disk: rebuild from numeric
+			// parts so untrusted network data is never written verbatim to the cache file.
+			const latest = data.version ? sanitizeVersion(data.version) : null;
+			if (!latest) return;
 
 			writeCache({ checkedAt: new Date().toISOString(), latest });
 
-			if (latest !== VERSION && latest !== "unknown" && isNewerVersion(latest, VERSION)) {
+			if (!quiet && latest !== VERSION && isNewerVersion(latest, VERSION)) {
 				showUpdateNotice(latest);
 			}
 		} catch {


### PR DESCRIPTION
## Summary

Brings CLI output in line with standard conventions and adds the missing config / auth / DX ergonomics, without changing behavior for scripts and pipelines.

**Output adapts to context:**
- Interactive terminal → a readable table (single objects as key/value; lists get a pagination footer; URLs are clickable).
- Piped or redirected (non-TTY) → JSON, exactly as before — so `elnora ... | jq`, redirects, and CI are unaffected.
- `--json` forces JSON on a terminal; `--md` emits Markdown; `--output json|csv|table|markdown` selects explicitly; `--compact` stays compact JSON; `--fields` works with every format. Raw file content stays lossless in every format.

**New / improved:**
- `elnora config show` — resolved endpoints, the active profile, and where the API key resolves from (never the key value); `key=value` on a terminal, JSON when piped. Adds an `ELNORA_MCP_URL` override.
- `elnora auth login --api-key-stdin` and `ELNORA_API_KEY` support, so the key need not appear on the process command line.
- A `-` value reads that input from stdin on the relevant commands (e.g. `cat protocol.md | elnora tasks send <id> --message -`).
- `elnora doctor` now detects shadow installs (more than one `elnora` on `PATH`) and prints the correct uninstall command for each.
- A branded startup banner on bare `elnora` / top-level `--help` (terminal only; never when piped, in CI, or with `--quiet`).
- Mistyped arguments now show a clean `field: message` error (exit 2) instead of a serialized parser dump.
- New global flags: `--quiet` (suppress spinners and update notices) and `--no-color`.
- Hardened the background update check: the registry version is validated before being cached.
- Added a Troubleshooting pointer to the platform skill (`elnora doctor` / `elnora config show`) so agents read real hosts instead of guessing.

## Compatibility

Piped/redirected output stays JSON, so existing scripts and pipelines are unaffected. README and `--help` updated to describe the new defaults.

## Testing

- [x] `pnpm lint`, `pnpm test`, `pnpm typecheck`, and `pnpm build` all pass
- [x] Tested locally with `node dist/cli.js` across the output formats (terminal vs piped), `config show`, `--api-key-stdin`, stdin `-`, `doctor`, and the validation error

## Linear Issue

Closes ELN-666
Closes ELN-776
Closes ELN-618
Closes ELN-603
Closes ELN-643
Closes ELN-778

🤖 Generated with [Claude Code](https://claude.com/claude-code)
