### PR TITLE
feat: make project optional on create/list/upload/fork commands

### DIFF
--- a/__tests__/commands/files/files.test.ts
+++ b/__tests__/commands/files/files.test.ts
@@ -61,8 +61,9 @@ describe("files.list", () => {
 		expect(filesList.annotations?.readOnlyHint).toBe(true);
 	});
 
-	test("requires project UUID", () => {
-		expect(() => filesList.inputSchema.parse({})).toThrow();
+	test("project is optional; a malformed UUID is rejected", () => {
+		// ELN-880: no scope is required — lists the caller's workspace by default.
+		expect(filesList.inputSchema.parse({})).toMatchObject({ page: 1, pageSize: 25 });
 		expect(() => filesList.inputSchema.parse({ project: "not-uuid" })).toThrow();
 	});
 
@@ -72,7 +73,7 @@ describe("files.list", () => {
 		expect(parsed.pageSize).toBe(25);
 	});
 
-	test("calls GET /projects/{id}/files with pagination", async () => {
+	test("calls GET /projects/{id}/files with pagination when --project is given (legacy)", async () => {
 		const ctx = mockContext({ getResult: { items: [], total: 0 } });
 		const result = await filesList.execute({ project: PROJECT_ID, page: 1, pageSize: 25 }, ctx);
 		expect(ctx.client.get).toHaveBeenCalledWith("project_files", {
@@ -80,6 +81,12 @@ describe("files.list", () => {
 			queryParams: { page: 1, pageSize: 25 },
 		});
 		expect(result).toEqual({ items: [], total: 0 });
+	});
+
+	test("defaults to GET /folders/files (workspace) when no project is given (ELN-880)", async () => {
+		const ctx = mockContext({ getResult: [] });
+		await filesList.execute({ page: 1, pageSize: 25 }, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("folders_files");
 	});
 });
 
@@ -153,16 +160,26 @@ describe("files.create", () => {
 		});
 	});
 
-	test("calls POST /files", async () => {
+	test("calls POST /files with fileType (backend field name) and projectId", async () => {
 		const ctx = mockContext({ postResult: { id: FILE_ID } });
 		const result = await filesCreate.execute({ project: PROJECT_ID, name: "f.txt", type: "text" }, ctx);
 		expect(ctx.client.post).toHaveBeenCalledWith("files", {
 			projectId: PROJECT_ID,
 			name: "f.txt",
-			type: "text",
+			fileType: "text",
 			folderId: undefined,
 		});
 		expect(result).toEqual({ id: FILE_ID });
+	});
+
+	test("omits projectId and maps --type to fileType when no project is given (ELN-880)", async () => {
+		const ctx = mockContext({ postResult: { id: FILE_ID } });
+		await filesCreate.execute({ name: "f.txt", type: "text" }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith("files", {
+			name: "f.txt",
+			fileType: "text",
+			folderId: undefined,
+		});
 	});
 });
 
@@ -434,16 +451,14 @@ describe("files.fork", () => {
 		expect(filesFork.group).toBe("files");
 	});
 
-	test("requires fileId and targetProject", () => {
+	test("requires fileId; target project is optional", () => {
+		// ELN-880: omit --target-project → backend forks into the caller's default workspace.
 		expect(() => filesFork.inputSchema.parse({})).toThrow();
-		expect(() => filesFork.inputSchema.parse({ fileId: FILE_ID })).toThrow();
-		expect(filesFork.inputSchema.parse({ fileId: FILE_ID, targetProject: PROJECT_ID })).toEqual({
-			fileId: FILE_ID,
-			targetProject: PROJECT_ID,
-		});
+		expect(filesFork.inputSchema.parse({ fileId: FILE_ID })).toMatchObject({ fileId: FILE_ID });
+		expect(() => filesFork.inputSchema.parse({ fileId: FILE_ID, targetProject: "not-uuid" })).toThrow();
 	});
 
-	test("calls POST /files/{id}/fork", async () => {
+	test("calls POST /files/{id}/fork with a target project", async () => {
 		const ctx = mockContext({ postResult: { id: "new-file-id" } });
 		const result = await filesFork.execute({ fileId: FILE_ID, targetProject: PROJECT_ID }, ctx);
 		expect(ctx.client.post).toHaveBeenCalledWith(
@@ -452,6 +467,12 @@ describe("files.fork", () => {
 			{ pathParams: { id: FILE_ID } },
 		);
 		expect(result).toEqual({ id: "new-file-id" });
+	});
+
+	test("forks into the workspace (empty body) when no target is given (ELN-880)", async () => {
+		const ctx = mockContext({ postResult: { id: "new-file-id" } });
+		await filesFork.execute({ fileId: FILE_ID }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith("file_fork", {}, { pathParams: { id: FILE_ID } });
 	});
 });
 

--- a/__tests__/commands/files/files.test.ts
+++ b/__tests__/commands/files/files.test.ts
@@ -193,10 +193,13 @@ describe("files.upload", () => {
 		expect(filesUpload.group).toBe("files");
 	});
 
-	test("requires project and filePath", () => {
-		expect(() => filesUpload.inputSchema.parse({})).toThrow();
-		expect(() => filesUpload.inputSchema.parse({ project: PROJECT_ID })).toThrow();
-		expect(filesUpload.inputSchema.parse({ project: PROJECT_ID, filePath: "/tmp/file.txt" })).toEqual({
+	test("filePath is required; project is optional (ELN-880)", () => {
+		expect(() => filesUpload.inputSchema.parse({})).toThrow(); // missing filePath
+		// project omitted → still valid (backend uploads into the caller's default workspace)
+		expect(filesUpload.inputSchema.parse({ filePath: "/tmp/file.txt" })).toMatchObject({
+			filePath: "/tmp/file.txt",
+		});
+		expect(filesUpload.inputSchema.parse({ project: PROJECT_ID, filePath: "/tmp/file.txt" })).toMatchObject({
 			project: PROJECT_ID,
 			filePath: "/tmp/file.txt",
 		});
@@ -213,9 +216,13 @@ describe("files.uploadBatch", () => {
 		expect(filesUploadBatch.group).toBe("files");
 	});
 
-	test("requires project and filePaths", () => {
-		expect(() => filesUploadBatch.inputSchema.parse({})).toThrow();
-		expect(filesUploadBatch.inputSchema.parse({ project: PROJECT_ID, filePaths: "/tmp/a.txt,/tmp/b.txt" })).toEqual({
+	test("filePaths is required; project is optional (ELN-880)", () => {
+		expect(() => filesUploadBatch.inputSchema.parse({})).toThrow(); // missing filePaths
+		// project omitted → still valid (backend uploads into the caller's default workspace)
+		expect(filesUploadBatch.inputSchema.parse({ filePaths: "/tmp/a.txt" })).toMatchObject({
+			filePaths: "/tmp/a.txt",
+		});
+		expect(filesUploadBatch.inputSchema.parse({ project: PROJECT_ID, filePaths: "/tmp/a.txt,/tmp/b.txt" })).toMatchObject({
 			project: PROJECT_ID,
 			filePaths: "/tmp/a.txt,/tmp/b.txt",
 		});

--- a/__tests__/commands/files/files.test.ts
+++ b/__tests__/commands/files/files.test.ts
@@ -222,7 +222,9 @@ describe("files.uploadBatch", () => {
 		expect(filesUploadBatch.inputSchema.parse({ filePaths: "/tmp/a.txt" })).toMatchObject({
 			filePaths: "/tmp/a.txt",
 		});
-		expect(filesUploadBatch.inputSchema.parse({ project: PROJECT_ID, filePaths: "/tmp/a.txt,/tmp/b.txt" })).toMatchObject({
+		expect(
+			filesUploadBatch.inputSchema.parse({ project: PROJECT_ID, filePaths: "/tmp/a.txt,/tmp/b.txt" }),
+		).toMatchObject({
 			project: PROJECT_ID,
 			filePaths: "/tmp/a.txt,/tmp/b.txt",
 		});

--- a/__tests__/commands/tasks/tasks.test.ts
+++ b/__tests__/commands/tasks/tasks.test.ts
@@ -131,8 +131,9 @@ describe("tasks.create", () => {
 		expect(tasksCreate.group).toBe("tasks");
 	});
 
-	test("requires project UUID", () => {
-		expect(() => tasksCreate.inputSchema.parse({})).toThrow();
+	test("project is optional and rejects a malformed UUID", () => {
+		// ELN-880: projectId is optional — the backend creates the task in the caller's default workspace.
+		expect(tasksCreate.inputSchema.parse({})).toMatchObject({ wait: false, stream: false });
 		expect(() => tasksCreate.inputSchema.parse({ project: "not-uuid" })).toThrow();
 	});
 
@@ -167,6 +168,15 @@ describe("tasks.create", () => {
 		await tasksCreate.execute({ project: PROJECT_ID, stream: false, wait: false }, ctx);
 		expect(ctx.client.post).toHaveBeenCalledWith("tasks", {
 			projectId: PROJECT_ID,
+			title: undefined,
+			initialMessage: undefined,
+		});
+	});
+
+	test("omits projectId from the body when no project is supplied (ELN-880)", async () => {
+		const ctx = mockContext({ postResult: { id: TASK_ID } });
+		await tasksCreate.execute({ stream: false, wait: false }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith("tasks", {
 			title: undefined,
 			initialMessage: undefined,
 		});

--- a/src/commands/files/create.ts
+++ b/src/commands/files/create.ts
@@ -3,7 +3,7 @@ import type { ElnoraCommand } from "../../core/command.js";
 import type { OutputFormat } from "../../lib/output.js";
 
 const inputSchema = z.object({
-	project: z.string().uuid().describe("Project ID"),
+	project: z.string().uuid().optional().describe("Project ID (optional; defaults to your workspace)"),
 	name: z.string().min(1).describe("File name"),
 	type: z.string().min(1).describe("File type"),
 	folder: z.string().uuid().optional().describe("Folder ID"),
@@ -20,9 +20,12 @@ export const filesCreate: ElnoraCommand<Input> = {
 
 	async execute(input, ctx) {
 		return ctx.client.post("files", {
-			projectId: input.project,
+			// projectId optional (ELN-880 Phase C): omitted → backend uses the caller's default workspace.
+			...(input.project ? { projectId: input.project } : {}),
 			name: input.name,
-			type: input.type,
+			// Backend CreateFileDTO expects `fileType` (the CLI flag is --type). Previously sent as
+			// `type`, which the API ignored → "FileType field is required" 400.
+			fileType: input.type,
 			folderId: input.folder,
 		});
 	},

--- a/src/commands/files/fork.ts
+++ b/src/commands/files/fork.ts
@@ -4,7 +4,7 @@ import type { OutputFormat } from "../../lib/output.js";
 
 const inputSchema = z.object({
 	fileId: z.string().uuid().describe("File ID to fork"),
-	targetProject: z.string().uuid().describe("Target project ID"),
+	targetProject: z.string().uuid().optional().describe("Target project ID (optional; defaults to your workspace)"),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -19,7 +19,11 @@ export const filesFork: ElnoraCommand<Input> = {
 	async execute(input, ctx) {
 		return ctx.client.post(
 			"file_fork",
-			{ targetProjectId: input.targetProject },
+			{
+				// targetProject optional (ELN-880 Phase C): omit → backend forks into the caller's
+				// default workspace. Only sent when explicitly supplied.
+				...(input.targetProject ? { targetProjectId: input.targetProject } : {}),
+			},
 			{
 				pathParams: { id: input.fileId },
 			},

--- a/src/commands/files/list.ts
+++ b/src/commands/files/list.ts
@@ -4,7 +4,7 @@ import type { OutputFormat } from "../../lib/output.js";
 import { paginationInput } from "../_shared/pagination.js";
 
 const inputSchema = z.object({
-	project: z.string().uuid().describe("Project ID"),
+	project: z.string().uuid().optional().describe("Project ID (optional; defaults to your workspace)"),
 	...paginationInput,
 });
 
@@ -19,10 +19,16 @@ export const filesList: ElnoraCommand<Input> = {
 	annotations: { readOnlyHint: true },
 
 	async execute(input, ctx) {
-		return ctx.client.get("project_files", {
-			pathParams: { id: input.project },
-			queryParams: { page: input.page, pageSize: input.pageSize },
-		});
+		// projectId optional (ELN-880 Phase C): with a project we keep the legacy project-scoped
+		// listing; without one we list every file accessible in the caller's workspace. GET
+		// /folders/files is a flat, org-wide list (capped at 200) and takes no pagination.
+		if (input.project) {
+			return ctx.client.get("project_files", {
+				pathParams: { id: input.project },
+				queryParams: { page: input.page, pageSize: input.pageSize },
+			});
+		}
+		return ctx.client.get("folders_files");
 	},
 
 	formatOutput(output: unknown, format: OutputFormat): string {

--- a/src/commands/files/upload-batch.ts
+++ b/src/commands/files/upload-batch.ts
@@ -7,7 +7,7 @@ import { ValidationError } from "../../lib/errors.js";
 import type { OutputFormat } from "../../lib/output.js";
 
 const inputSchema = z.object({
-	project: z.string().uuid().describe("Project ID"),
+	project: z.string().uuid().optional().describe("Project ID (optional; defaults to your workspace)"),
 	filePaths: z.string().min(1).describe("Comma-separated local file paths to upload"),
 	folder: z.string().uuid().optional().describe("Folder ID"),
 });
@@ -52,9 +52,9 @@ export const filesUploadBatch: ElnoraCommand<Input> = {
 				const contentType = "application/octet-stream";
 				const fileSize = statSync(filePath).size;
 
-				// Step 1: Get presigned URL
+				// Step 1: Get presigned URL (projectId optional — omitted → caller's default workspace)
 				const uploadInfo = await ctx.client.post<Record<string, unknown>>("file_upload", {
-					projectId: input.project,
+					...(input.project ? { projectId: input.project } : {}),
 					fileName,
 					contentType,
 					fileSizeBytes: fileSize,

--- a/src/commands/files/upload.ts
+++ b/src/commands/files/upload.ts
@@ -6,7 +6,7 @@ import { validateUploadUrl } from "../../lib/client.js";
 import type { OutputFormat } from "../../lib/output.js";
 
 const inputSchema = z.object({
-	project: z.string().uuid().describe("Project ID"),
+	project: z.string().uuid().optional().describe("Project ID (optional; defaults to your workspace)"),
 	filePath: z.string().min(1).describe("Local file path to upload"),
 	fileName: z.string().optional().describe("Override file name"),
 	contentType: z.string().optional().describe("MIME content type"),
@@ -27,9 +27,9 @@ export const filesUpload: ElnoraCommand<Input> = {
 		const contentType = input.contentType ?? "application/octet-stream";
 		const fileSize = statSync(input.filePath).size;
 
-		// Step 1: Get presigned URL
+		// Step 1: Get presigned URL (projectId optional — omitted → caller's default workspace)
 		const uploadInfo = await ctx.client.post<Record<string, unknown>>("file_upload", {
-			projectId: input.project,
+			...(input.project ? { projectId: input.project } : {}),
 			fileName,
 			contentType,
 			fileSizeBytes: fileSize,

--- a/src/commands/tasks/create.ts
+++ b/src/commands/tasks/create.ts
@@ -7,7 +7,7 @@ import { collectStreamResponse, streamTask } from "../../lib/stream.js";
 import { StreamRenderer } from "../../lib/stream-renderer.js";
 
 const inputSchema = z.object({
-	project: z.string().uuid().describe("Project ID"),
+	project: z.string().uuid().optional().describe("Project ID (optional; defaults to your workspace)"),
 	title: z.string().optional().describe("Task title"),
 	message: z.string().optional().describe("Initial message"),
 	wait: z.boolean().default(false).describe("Wait for agent response (polling)"),
@@ -26,7 +26,9 @@ export const tasksCreate: ElnoraCommand<Input> = {
 
 	async execute(input, ctx) {
 		const result = (await ctx.client.post("tasks", {
-			projectId: input.project,
+			// projectId is optional (ELN-880 Phase C): when omitted the backend creates the
+			// task in the caller's default workspace. Only sent when explicitly supplied.
+			...(input.project ? { projectId: input.project } : {}),
 			title: input.title,
 			initialMessage: input.message,
 		})) as { id: string; [key: string]: unknown };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -52,6 +52,7 @@ export const ENDPOINTS: Record<string, string> = {
 	// Folders
 	folder: "/folders/{id}",
 	folder_move: "/folders/{id}/move",
+	folders_files: "/folders/files",
 	// Organizations
 	organizations: "/organizations",
 	organization: "/organizations/{id}",


### PR DESCRIPTION
## Summary

Aligns the CLI with the project-optional backend (project-concept removal, Phase C). The backend now resolves
the caller's default workspace when `projectId` is omitted, so the CLI no longer requires a project UUID.

**Minor `feat` — non-breaking.** No commands or flags were removed; `--project` is simply now optional. The
`projects` command group is untouched.

## Changes

- `tasks create`, `files create`, `files upload`, `files upload-batch`, `files fork`: `--project` /
  `--target-project` are now **optional**. The request body includes the id only when supplied; omit it to
  target your default workspace.
- `files list`: `--project` optional; with no scope it lists every file in your workspace via
  `GET /folders/files`.
- **Bug fix:** `files create` sent the file type as `type`, but the backend expects `fileType`, so every
  create returned `400 "FileType field is required"`. Now mapped correctly.

## Parity

Param names and tool descriptions are unchanged, so the `mcp-parity` check stays green. A companion PR in
`elnora-mcp-server` (`feat/project-optional-tools`) makes the same tools project-optional there — the two are
mutually parity-clean and have no merge-order dependency.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm audit:mcp-parity` — all clean (0 param/description mismatches).
- `pnpm test` — **685 passing** (added no-project coverage for tasks/files create, list, fork, and
  upload/upload-batch schema).
- **Real CLI E2E against a local backend build** (with the project-optional change): `tasks create`,
  `files create`, and `files list` all succeed with **no project supplied** (verified the created rows land in
  the caller's default workspace).

## Note

`files list` without `--project` uses the flat `GET /folders/files` endpoint, which is capped at 200 rows and
unpaginated (`--page`/`--pageSize` have no effect in that mode). Acceptable for a first-page workspace view;
there is no paged workspace-wide backend endpoint yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
