### PR TITLE
fix: use PUT for account update; restore tool-description parity

### DIFF
--- a/__tests__/commands/account/account.test.ts
+++ b/__tests__/commands/account/account.test.ts
@@ -77,16 +77,17 @@ describe("account.update", () => {
 		await expect(accountUpdate.execute({ userId: "123" }, ctx)).rejects.toThrow(ValidationError);
 	});
 
-	test("calls PATCH account_user with firstName", async () => {
-		const ctx = mockContext({ patchResult: {} });
+	test("calls PUT account_user with firstName (backend is PUT-only, not PATCH)", async () => {
+		const ctx = mockContext({ putResult: {} });
 		await accountUpdate.execute({ userId: "123", firstName: "Jane" }, ctx);
-		expect(ctx.client.patch).toHaveBeenCalledWith(
+		expect(ctx.client.put).toHaveBeenCalledWith(
 			"account_user",
 			{ firstName: "Jane" },
 			{
 				pathParams: { id: "123" },
 			},
 		);
+		expect(ctx.client.patch).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/commands/account/update.ts
+++ b/src/commands/account/update.ts
@@ -25,7 +25,8 @@ export const accountUpdate: ElnoraCommand<Input> = {
 		if (Object.keys(body).length === 0) {
 			throw new ValidationError("At least one of --firstName or --lastName is required");
 		}
-		return ctx.client.patch("account_user", body, {
+		// Backend exposes PUT /account/user/{id} (no PATCH) — using PATCH here 405'd.
+		return ctx.client.put("account_user", body, {
 			pathParams: { id: input.userId },
 		});
 	},

--- a/src/commands/protocols/generate.ts
+++ b/src/commands/protocols/generate.ts
@@ -18,7 +18,8 @@ type Input = z.infer<typeof inputSchema>;
 export const protocolsGenerate: ElnoraCommand<Input> = {
 	name: "protocols.generate",
 	group: "protocols",
-	description: "Generate a bioprotocol — creates a task and sends the description in one call",
+	description:
+		"Generate a bioprotocol — creates a task and sends the description in one call. Returns the task and the queued user message, NOT the AI response; the agent processes asynchronously. To get the generated protocol, poll elnora_tasks_messages with the returned task id every 5-10s until the last message has role 'assistant' with metadata.status 'completed'. Timeout after 5 min.",
 	stdinField: "description",
 	inputSchema,
 	outputSchema: z.any(),

--- a/src/commands/tasks/create.ts
+++ b/src/commands/tasks/create.ts
@@ -19,7 +19,8 @@ type Input = z.infer<typeof inputSchema>;
 export const tasksCreate: ElnoraCommand<Input> = {
 	name: "tasks.create",
 	group: "tasks",
-	description: "Create a new task in a project",
+	description:
+		"Create a new task in a project. If a message is provided it is queued, but the AI response is NOT returned — the agent processes asynchronously. Poll elnora_tasks_messages every 5-10s until the last message has role 'assistant' with metadata.status 'completed'. Timeout after 5 min.",
 	stdinField: "message",
 	inputSchema,
 	outputSchema: z.any(),

--- a/src/commands/tasks/send.ts
+++ b/src/commands/tasks/send.ts
@@ -21,7 +21,8 @@ type Input = z.infer<typeof inputSchema>;
 export const tasksSend: ElnoraCommand<Input> = {
 	name: "tasks.send",
 	group: "tasks",
-	description: "Send a message to a task",
+	description:
+		"Send a message to a task. Returns the created user message immediately — the agent processes asynchronously. To get the AI response, poll elnora_tasks_messages until the last message has role 'assistant' with metadata.status 'completed'. Poll every 5-10s, timeout after 5 min.",
 	stdinField: "message",
 	inputSchema,
 	outputSchema: z.any(),


### PR DESCRIPTION
## Summary

Two fixes:

1. **`account update` used the wrong verb.** It sent `PATCH /account/user/{id}`, but the backend only exposes
   `PUT` for that route, so it 405'd. Switched to `PUT` (+ updated test).
2. **Restore CLI↔MCP description parity.** `tasks.create`, `tasks.send`, and `protocols.generate` had shorter
   descriptions than their matching MCP tools (the MCP catalog work enriched only the MCP side), which broke
   the `mcp-parity` check and blocks every CLI PR. Adopted the richer MCP descriptions verbatim.

`typecheck`, `lint`, `test` (685), and `audit:mcp-parity` (0 mismatches) all green.
