### PR TITLE
feat(folders): add Knowledge Base folder read commands

### DIFF
--- a/__tests__/commands/folders/folders.test.ts
+++ b/__tests__/commands/folders/folders.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test, vi } from "vitest";
+import { foldersChildren } from "../../../src/commands/folders/children.js";
 import { foldersCreate } from "../../../src/commands/folders/create.js";
 import { foldersDelete } from "../../../src/commands/folders/delete.js";
+import { foldersFiles } from "../../../src/commands/folders/files.js";
+import { foldersGet } from "../../../src/commands/folders/get.js";
 import { registerFolderCommands } from "../../../src/commands/folders/index.js";
 import { foldersList } from "../../../src/commands/folders/list.js";
 import { foldersMove } from "../../../src/commands/folders/move.js";
 import { foldersRename } from "../../../src/commands/folders/rename.js";
+import { foldersRoots } from "../../../src/commands/folders/roots.js";
 import type { CommandContext } from "../../../src/core/command.js";
 import { ValidationError } from "../../../src/lib/errors.js";
 
@@ -187,13 +191,71 @@ describe("folders.delete", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Knowledge Base read commands (roots / children / get / files)
+// ---------------------------------------------------------------------------
+
+describe("folders.roots", () => {
+	test("is read-only and takes no args", () => {
+		expect(foldersRoots.annotations?.readOnlyHint).toBe(true);
+		expect(foldersRoots.inputSchema.parse({})).toEqual({});
+	});
+
+	test("calls GET /folders/roots", async () => {
+		const ctx = mockContext({ getResult: [{ id: FOLDER_ID, name: "Knowledge Base" }] });
+		await foldersRoots.execute({}, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("folder_roots");
+	});
+});
+
+describe("folders.children", () => {
+	test("requires a valid folderId", () => {
+		expect(() => foldersChildren.inputSchema.parse({})).toThrow();
+		expect(() => foldersChildren.inputSchema.parse({ folderId: "bad" })).toThrow();
+	});
+
+	test("calls GET /folders/{id}/children", async () => {
+		const ctx = mockContext({ getResult: [] });
+		await foldersChildren.execute({ folderId: FOLDER_ID }, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("folder_children", { pathParams: { id: FOLDER_ID } });
+	});
+});
+
+describe("folders.get", () => {
+	test("requires a valid folderId", () => {
+		expect(() => foldersGet.inputSchema.parse({})).toThrow();
+	});
+
+	test("calls GET /folders/{id}", async () => {
+		const ctx = mockContext({ getResult: { id: FOLDER_ID, breadcrumbs: [] } });
+		await foldersGet.execute({ folderId: FOLDER_ID }, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("folder", { pathParams: { id: FOLDER_ID } });
+	});
+});
+
+describe("folders.files", () => {
+	test("requires a valid folderId and defaults pagination", () => {
+		expect(() => foldersFiles.inputSchema.parse({})).toThrow();
+		expect(foldersFiles.inputSchema.parse({ folderId: FOLDER_ID })).toMatchObject({ page: 1, pageSize: 25 });
+	});
+
+	test("calls GET /folders/{id}/files with pagination", async () => {
+		const ctx = mockContext({ getResult: { items: [], totalCount: 0 } });
+		await foldersFiles.execute({ folderId: FOLDER_ID, page: 1, pageSize: 25 }, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("folder_files", {
+			pathParams: { id: FOLDER_ID },
+			queryParams: { page: 1, pageSize: 25 },
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
 // registerFolderCommands
 // ---------------------------------------------------------------------------
 
 describe("registerFolderCommands", () => {
-	test("returns all 5 folder commands", () => {
+	test("returns all 9 folder commands", () => {
 		const commands = registerFolderCommands();
-		expect(commands).toHaveLength(5);
+		expect(commands).toHaveLength(9);
 	});
 
 	test("all commands belong to folders group", () => {

--- a/skills/elnora-folders/SKILL.md
+++ b/skills/elnora-folders/SKILL.md
@@ -1,14 +1,32 @@
 ---
 name: elnora-folders
 description: >
-  This skill should be used when the user asks to "create folder", "list folders",
-  "rename folder", "move folder", "delete folder", "organize files into folders",
-  or any task involving Elnora Platform project folder management.
+  This skill should be used when the user asks to "browse the knowledge base",
+  "list KB folders", "show my folders", "open a folder", "create folder",
+  "list folders", "rename folder", "move folder", "delete folder", "organize files
+  into folders", or any task involving Elnora Platform folder management.
 ---
 
 # Elnora Folders
 
-Manage the folder tree within Elnora projects.
+Browse and manage folders in Elnora. The **Knowledge Base** is the current folder
+model (a workspace-wide tree with per-folder sharing); the older *project folder*
+commands are legacy and take a `<PROJECT_ID>`.
+
+## Browse the Knowledge Base
+
+Start at the roots and walk the tree — you need a folder ID from here before you can
+list its children or files.
+
+```bash
+$CLI --compact folders roots                 # top-level KB folders (Knowledge Base, memory, tasks, uploads, …)
+$CLI --compact folders children <FOLDER_ID>  # child folders of a folder
+$CLI --compact folders get <FOLDER_ID>       # folder details + breadcrumb path to root
+$CLI --compact folders files <FOLDER_ID>     # files placed directly in a folder (paged: --page / --page-size)
+```
+
+`folders roots` takes no arguments (the org comes from your token). The others take a
+positional `<FOLDER_ID>` (`folderId`).
 
 ## Tool Access
 
@@ -88,6 +106,10 @@ Destructive — confirm with user before running.
 
 | CLI command | MCP tool name |
 |-------------|---------------|
+| `folders roots` | `elnora_folders_roots` |
+| `folders children` | `elnora_folders_children` |
+| `folders get` | `elnora_folders_get` |
+| `folders files` | `elnora_folders_files` |
 | `folders list` | `elnora_folders_list` |
 | `folders create` | `elnora_folders_create` |
 | `folders rename` | `elnora_folders_rename` |

--- a/src/commands/folders/children.ts
+++ b/src/commands/folders/children.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	folderId: z.string().uuid().describe("Folder ID"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const foldersChildren: ElnoraCommand<Input> = {
+	name: "folders.children",
+	group: "folders",
+	description: "List the child folders of a Knowledge Base folder",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { readOnlyHint: true },
+
+	async execute(input, ctx) {
+		return ctx.client.get("folder_children", {
+			pathParams: { id: input.folderId },
+		});
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/folders/files.ts
+++ b/src/commands/folders/files.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+import { paginationInput } from "../_shared/pagination.js";
+
+const inputSchema = z.object({
+	folderId: z.string().uuid().describe("Folder ID"),
+	...paginationInput,
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const foldersFiles: ElnoraCommand<Input> = {
+	name: "folders.files",
+	group: "folders",
+	description: "List files placed directly in a Knowledge Base folder",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { readOnlyHint: true },
+
+	async execute(input, ctx) {
+		return ctx.client.get("folder_files", {
+			pathParams: { id: input.folderId },
+			queryParams: { page: input.page, pageSize: input.pageSize },
+		});
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/folders/get.ts
+++ b/src/commands/folders/get.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	folderId: z.string().uuid().describe("Folder ID"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const foldersGet: ElnoraCommand<Input> = {
+	name: "folders.get",
+	group: "folders",
+	description: "Get a Knowledge Base folder's details and breadcrumb path",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { readOnlyHint: true },
+
+	async execute(input, ctx) {
+		return ctx.client.get("folder", {
+			pathParams: { id: input.folderId },
+		});
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/folders/index.ts
+++ b/src/commands/folders/index.ts
@@ -1,12 +1,36 @@
 import type { ElnoraCommand } from "../../core/command.js";
+import { foldersChildren } from "./children.js";
 import { foldersCreate } from "./create.js";
 import { foldersDelete } from "./delete.js";
+import { foldersFiles } from "./files.js";
+import { foldersGet } from "./get.js";
 import { foldersList } from "./list.js";
 import { foldersMove } from "./move.js";
 import { foldersRename } from "./rename.js";
+import { foldersRoots } from "./roots.js";
 
 export function registerFolderCommands(): ElnoraCommand[] {
-	return [foldersList, foldersCreate, foldersRename, foldersMove, foldersDelete];
+	return [
+		foldersRoots,
+		foldersChildren,
+		foldersGet,
+		foldersFiles,
+		foldersList,
+		foldersCreate,
+		foldersRename,
+		foldersMove,
+		foldersDelete,
+	];
 }
 
-export { foldersCreate, foldersDelete, foldersList, foldersMove, foldersRename };
+export {
+	foldersChildren,
+	foldersCreate,
+	foldersDelete,
+	foldersFiles,
+	foldersGet,
+	foldersList,
+	foldersMove,
+	foldersRename,
+	foldersRoots,
+};

--- a/src/commands/folders/roots.ts
+++ b/src/commands/folders/roots.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const foldersRoots: ElnoraCommand<Input> = {
+	name: "folders.roots",
+	group: "folders",
+	description: "List the top-level Knowledge Base folders you can access",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { readOnlyHint: true },
+
+	async execute(_input, ctx) {
+		return ctx.client.get("folder_roots");
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -49,10 +49,14 @@ export const ENDPOINTS: Record<string, string> = {
 	file_working_copy: "/files/{id}/working-copy",
 	file_commit: "/files/{id}/commit",
 	file_upload_batch: "/files/upload/batch",
-	// Folders
+	// Folders (closure-table Knowledge Base — the `folder`/`folder_move` paths are shared with the
+	// legacy controller; the KB read/mutation verbs are distinguished by HTTP method at the call site)
 	folder: "/folders/{id}",
 	folder_move: "/folders/{id}/move",
 	folders_files: "/folders/files",
+	folder_roots: "/folders/roots",
+	folder_children: "/folders/{id}/children",
+	folder_files: "/folders/{id}/files",
 	// Organizations
 	organizations: "/organizations",
 	organization: "/organizations/{id}",


### PR DESCRIPTION
## Summary

Adds four **read-only** commands for browsing the Knowledge Base folder tree, mirroring the new elnora-mcp-server tools so CLI callers can navigate the current folder model instead of only the legacy project-scoped one.

| Command | Calls | Returns |
|---|---|---|
| `folders roots` | `GET /folders/roots` | Top-level folders you can access (no args) |
| `folders children <folderId>` | `GET /folders/{id}/children` | Child folders of a folder |
| `folders get <folderId>` | `GET /folders/{id}` | Folder details + breadcrumb path to root |
| `folders files <folderId>` | `GET /folders/{id}/files` | Files placed directly in a folder (`--page` / `--page-size`) |

The existing project-scoped folder commands are unchanged. This is the first slice of bringing the `folders` group up to date with the Knowledge Base; mutation/repoint and sharing follow separately.

## Changes

- `src/commands/folders/{roots,children,get,files}.ts` — new read commands (all `readOnlyHint`)
- `src/commands/folders/index.ts`, `src/lib/config.ts` — register commands + endpoint keys
- `__tests__/commands/folders/folders.test.ts` — per-command tests + registration count
- `skills/elnora-folders/SKILL.md` — document the browse commands + MCP tool-name mapping

## Testing

- `pnpm typecheck` / `pnpm lint` clean
- `pnpm test` — 693 passing
- Verified end-to-end against a local backend (roots → children → get → files)

## Merge order

The MCP-parity check compares against `elnora-mcp-server@main`. It stays red until the paired MCP PR merges, then goes green on re-run — please merge that one first.