### PR TITLE
feat(sharing): file & folder sharing, file move, and member directory

### DIFF
--- a/__tests__/commands/files/files.test.ts
+++ b/__tests__/commands/files/files.test.ts
@@ -10,9 +10,13 @@ import { filesFork } from "../../../src/commands/files/fork.js";
 import { filesGet } from "../../../src/commands/files/get.js";
 import { registerFileCommands } from "../../../src/commands/files/index.js";
 import { filesList } from "../../../src/commands/files/list.js";
+import { filesMove } from "../../../src/commands/files/move.js";
 import { filesPromote } from "../../../src/commands/files/promote.js";
 import { filesRestore } from "../../../src/commands/files/restore.js";
 import { filesSearchContent } from "../../../src/commands/files/search-content.js";
+import { filesShare } from "../../../src/commands/files/share.js";
+import { filesShares } from "../../../src/commands/files/shares.js";
+import { filesUnshare } from "../../../src/commands/files/unshare.js";
 import { filesUpdate } from "../../../src/commands/files/update.js";
 import { filesUpload } from "../../../src/commands/files/upload.js";
 import { filesUploadBatch } from "../../../src/commands/files/upload-batch.js";
@@ -25,6 +29,8 @@ import { ValidationError } from "../../../src/lib/errors.js";
 const FILE_ID = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
 const PROJECT_ID = "d5c4b3a2-f6e5-4b7a-9d8c-1f0e2a3b4c5d";
 const VERSION_ID = "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e";
+const FOLDER_ID = "c3d4e5f6-a7b8-4c9d-8e0f-2a3b4c5d6e7f";
+const ACE_ID = "e5f6a7b8-c9d0-4e1f-9a2b-3c4d5e6f7a8b";
 
 function mockContext(overrides?: {
 	getResult?: unknown;
@@ -572,13 +578,90 @@ describe("files.searchContent", () => {
 });
 
 // ---------------------------------------------------------------------------
+// files.move / share / unshare / shares (KB Access V2)
+// ---------------------------------------------------------------------------
+
+describe("files.move", () => {
+	test("has correct name and group", () => {
+		expect(filesMove.name).toBe("files.move");
+		expect(filesMove.group).toBe("files");
+	});
+
+	test("PATCHes file_move with parentFolderId", async () => {
+		const ctx = mockContext({ patchResult: { id: FILE_ID } });
+		await filesMove.execute({ fileId: FILE_ID, parentFolderId: FOLDER_ID }, ctx);
+		expect(ctx.client.patch).toHaveBeenCalledWith(
+			"file_move",
+			{ parentFolderId: FOLDER_ID },
+			{ pathParams: { id: FILE_ID } },
+		);
+	});
+});
+
+describe("files.share", () => {
+	test("shares with a specific user (POST file_share)", async () => {
+		const ctx = mockContext({ postResult: { id: ACE_ID } });
+		await filesShare.execute({ fileId: FILE_ID, userId: 42, orgWide: false, role: "editor" }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith(
+			"file_share",
+			{ userId: 42, role: "editor" },
+			{ pathParams: { id: FILE_ID } },
+		);
+	});
+
+	test("shares org-wide", async () => {
+		const ctx = mockContext({ postResult: { id: ACE_ID } });
+		await filesShare.execute({ fileId: FILE_ID, orgWide: true, role: "viewer" }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith(
+			"file_share",
+			{ isOrgWide: true, role: "viewer" },
+			{ pathParams: { id: FILE_ID } },
+		);
+	});
+
+	test("rejects both user and org-wide", async () => {
+		const ctx = mockContext();
+		await expect(
+			filesShare.execute({ fileId: FILE_ID, userId: 42, orgWide: true, role: "editor" }, ctx),
+		).rejects.toThrow(ValidationError);
+	});
+
+	test("rejects neither user nor org-wide", async () => {
+		const ctx = mockContext();
+		await expect(filesShare.execute({ fileId: FILE_ID, orgWide: false, role: "editor" }, ctx)).rejects.toThrow(
+			ValidationError,
+		);
+	});
+});
+
+describe("files.unshare", () => {
+	test("DELETEs file_share_ace and returns revoked", async () => {
+		const ctx = mockContext();
+		const result = await filesUnshare.execute({ fileId: FILE_ID, aceId: ACE_ID }, ctx);
+		expect(ctx.client.del).toHaveBeenCalledWith("file_share_ace", {
+			pathParams: { id: FILE_ID, aceId: ACE_ID },
+		});
+		expect(result).toEqual({ revoked: true, fileId: FILE_ID, aceId: ACE_ID });
+	});
+});
+
+describe("files.shares", () => {
+	test("is read-only and GETs file_shares", async () => {
+		const ctx = mockContext({ getResult: [] });
+		expect(filesShares.annotations?.readOnlyHint).toBe(true);
+		await filesShares.execute({ fileId: FILE_ID }, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("file_shares", { pathParams: { id: FILE_ID } });
+	});
+});
+
+// ---------------------------------------------------------------------------
 // registerFileCommands
 // ---------------------------------------------------------------------------
 
 describe("registerFileCommands", () => {
-	test("returns all 19 file commands", () => {
+	test("returns all 23 file commands", () => {
 		const commands = registerFileCommands();
-		expect(commands).toHaveLength(19);
+		expect(commands).toHaveLength(23);
 	});
 
 	test("all commands belong to files group", () => {

--- a/__tests__/commands/folders/folders.test.ts
+++ b/__tests__/commands/folders/folders.test.ts
@@ -9,12 +9,16 @@ import { foldersList } from "../../../src/commands/folders/list.js";
 import { foldersMove } from "../../../src/commands/folders/move.js";
 import { foldersRename } from "../../../src/commands/folders/rename.js";
 import { foldersRoots } from "../../../src/commands/folders/roots.js";
+import { foldersShare } from "../../../src/commands/folders/share.js";
+import { foldersShares } from "../../../src/commands/folders/shares.js";
+import { foldersUnshare } from "../../../src/commands/folders/unshare.js";
 import type { CommandContext } from "../../../src/core/command.js";
 import { ValidationError } from "../../../src/lib/errors.js";
 
 const PROJECT_ID = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
 const FOLDER_ID = "d5c4b3a2-f6e5-4b7a-9d8c-1f0e2a3b4c5d";
 const PARENT_ID = "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e";
+const ACE_ID = "e5f6a7b8-c9d0-4e1f-9a2b-3c4d5e6f7a8b";
 
 function mockContext(overrides?: {
 	getResult?: unknown;
@@ -249,13 +253,66 @@ describe("folders.files", () => {
 });
 
 // ---------------------------------------------------------------------------
+// folders.share / unshare / shares (KB Access V2)
+// ---------------------------------------------------------------------------
+
+describe("folders.share", () => {
+	test("shares with a specific user (POST folder_share)", async () => {
+		const ctx = mockContext({ postResult: { id: ACE_ID } });
+		await foldersShare.execute({ folderId: FOLDER_ID, userId: 42, orgWide: false, role: "editor" }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith(
+			"folder_share",
+			{ userId: 42, role: "editor" },
+			{ pathParams: { id: FOLDER_ID } },
+		);
+	});
+
+	test("shares org-wide", async () => {
+		const ctx = mockContext({ postResult: { id: ACE_ID } });
+		await foldersShare.execute({ folderId: FOLDER_ID, orgWide: true, role: "admin" }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith(
+			"folder_share",
+			{ isOrgWide: true, role: "admin" },
+			{ pathParams: { id: FOLDER_ID } },
+		);
+	});
+
+	test("rejects both user and org-wide", async () => {
+		const ctx = mockContext();
+		await expect(
+			foldersShare.execute({ folderId: FOLDER_ID, userId: 42, orgWide: true, role: "editor" }, ctx),
+		).rejects.toThrow(ValidationError);
+	});
+});
+
+describe("folders.unshare", () => {
+	test("DELETEs folder_share_ace and returns revoked", async () => {
+		const ctx = mockContext();
+		const result = await foldersUnshare.execute({ folderId: FOLDER_ID, aceId: ACE_ID }, ctx);
+		expect(ctx.client.del).toHaveBeenCalledWith("folder_share_ace", {
+			pathParams: { id: FOLDER_ID, aceId: ACE_ID },
+		});
+		expect(result).toEqual({ revoked: true, folderId: FOLDER_ID, aceId: ACE_ID });
+	});
+});
+
+describe("folders.shares", () => {
+	test("is read-only and GETs folder_shares", async () => {
+		const ctx = mockContext({ getResult: [] });
+		expect(foldersShares.annotations?.readOnlyHint).toBe(true);
+		await foldersShares.execute({ folderId: FOLDER_ID }, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("folder_shares", { pathParams: { id: FOLDER_ID } });
+	});
+});
+
+// ---------------------------------------------------------------------------
 // registerFolderCommands
 // ---------------------------------------------------------------------------
 
 describe("registerFolderCommands", () => {
-	test("returns all 9 folder commands", () => {
+	test("returns all 12 folder commands", () => {
 		const commands = registerFolderCommands();
-		expect(commands).toHaveLength(9);
+		expect(commands).toHaveLength(12);
 	});
 
 	test("all commands belong to folders group", () => {

--- a/__tests__/commands/orgs/orgs.test.ts
+++ b/__tests__/commands/orgs/orgs.test.ts
@@ -4,6 +4,7 @@ import { orgsBilling } from "../../../src/commands/orgs/billing.js";
 import { orgsCancelInvite } from "../../../src/commands/orgs/cancel-invite.js";
 import { orgsCreate } from "../../../src/commands/orgs/create.js";
 import { orgsDelete } from "../../../src/commands/orgs/delete.js";
+import { orgsDirectory } from "../../../src/commands/orgs/directory.js";
 import { orgsFiles } from "../../../src/commands/orgs/files.js";
 import { orgsGet } from "../../../src/commands/orgs/get.js";
 import { registerOrgCommands } from "../../../src/commands/orgs/index.js";
@@ -562,13 +563,37 @@ describe("orgs.listAll", () => {
 });
 
 // ---------------------------------------------------------------------------
+// orgs.directory (Share-modal member typeahead)
+// ---------------------------------------------------------------------------
+
+describe("orgs.directory", () => {
+	test("is read-only and GETs the member directory with q", async () => {
+		const ctx = mockContext({ getResult: [] });
+		expect(orgsDirectory.annotations?.readOnlyHint).toBe(true);
+		await orgsDirectory.execute({ orgId: ORG_ID, query: "ada" }, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("org_member_directory", {
+			pathParams: { orgId: ORG_ID },
+			queryParams: { q: "ada" },
+		});
+	});
+
+	test("requires a query of at least 2 characters", () => {
+		expect(() => orgsDirectory.inputSchema.parse({ orgId: ORG_ID, query: "a" })).toThrow();
+		expect(orgsDirectory.inputSchema.parse({ orgId: ORG_ID, query: "ab" })).toEqual({
+			orgId: ORG_ID,
+			query: "ab",
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
 // registerOrgCommands
 // ---------------------------------------------------------------------------
 
 describe("registerOrgCommands", () => {
-	test("returns all 19 org commands", () => {
+	test("returns all 20 org commands", () => {
 		const commands = registerOrgCommands();
-		expect(commands).toHaveLength(19);
+		expect(commands).toHaveLength(20);
 	});
 
 	test("all commands belong to orgs group", () => {

--- a/skills/elnora-files/SKILL.md
+++ b/skills/elnora-files/SKILL.md
@@ -230,6 +230,40 @@ Full-text search inside file contents. Also available as `search file-content`.
 | `--page` | No | Page number (default 1) |
 | `--page-size` | No | Results per page (default 25, max 100) |
 
+### Move File
+
+```bash
+$CLI --compact files move <FILE_ID> <PARENT_FOLDER_ID>
+```
+
+Move a file into a different Knowledge Base folder. Both `<FILE_ID>` and `<PARENT_FOLDER_ID>` are positional. You need write access on both the file's current folder and the destination.
+
+### Share File
+
+```bash
+$CLI --compact files share <FILE_ID> --user-id <USER_ID>
+$CLI --compact files share <FILE_ID> --user-id <USER_ID> --role viewer
+$CLI --compact files share <FILE_ID> --org-wide
+```
+
+Grant access to a file. Provide **exactly one** recipient: `--user-id` (a specific member) or `--org-wide` (everyone in the organization).
+
+| Flag/Arg | Required | Notes |
+|----------|----------|-------|
+| `<FILE_ID>` | Yes | Positional — file UUID |
+| `--user-id` | * | Member's numeric user id. Find it with `orgs directory`. |
+| `--org-wide` | * | Share with the whole organization |
+| `--role` | No | `viewer`, `editor` (default), or `admin` |
+
+\* Exactly one of `--user-id` / `--org-wide` is required.
+
+### List / Revoke File Shares
+
+```bash
+$CLI --compact files shares <FILE_ID>              # list current shares (each has an "id" = ACE id)
+$CLI --compact files unshare <FILE_ID> <ACE_ID>    # revoke one share
+```
+
 ## MCP Tool Names
 
 | CLI command | MCP tool name |
@@ -253,6 +287,10 @@ Full-text search inside file contents. Also available as `search file-content`.
 | `files working-copy` | `elnora_files_workingCopy` |
 | `files commit` | `elnora_files_commit` |
 | `files search-content` | `elnora_files_searchContent` |
+| `files move` | `elnora_files_move` |
+| `files share` | `elnora_files_share` |
+| `files unshare` | `elnora_files_unshare` |
+| `files shares` | `elnora_files_shares` |
 
 ## Agent Recipes
 

--- a/skills/elnora-folders/SKILL.md
+++ b/skills/elnora-folders/SKILL.md
@@ -102,6 +102,22 @@ $CLI --compact folders delete <FOLDER_ID>
 
 Destructive — confirm with user before running.
 
+### Share a Folder
+
+```bash
+$CLI --compact folders share <FOLDER_ID> --user-id <USER_ID>
+$CLI --compact folders share <FOLDER_ID> --org-wide --role viewer
+```
+
+Grant access to a folder (sub-folders and files inherit it). Provide **exactly one** recipient: `--user-id` (a specific member — find the id with `orgs directory`) or `--org-wide`. `--role` is `viewer`, `editor` (default), or `admin`.
+
+### List / Revoke Folder Shares
+
+```bash
+$CLI --compact folders shares <FOLDER_ID>            # list current shares (each has an "id" = ACE id)
+$CLI --compact folders unshare <FOLDER_ID> <ACE_ID>  # revoke one share
+```
+
 ## MCP Tool Names
 
 | CLI command | MCP tool name |
@@ -115,6 +131,9 @@ Destructive — confirm with user before running.
 | `folders rename` | `elnora_folders_rename` |
 | `folders move` | `elnora_folders_move` |
 | `folders delete` | `elnora_folders_delete` |
+| `folders share` | `elnora_folders_share` |
+| `folders unshare` | `elnora_folders_unshare` |
+| `folders shares` | `elnora_folders_shares` |
 
 ## Agent Recipes
 

--- a/skills/elnora-orgs/SKILL.md
+++ b/skills/elnora-orgs/SKILL.md
@@ -109,6 +109,14 @@ $CLI --compact orgs files <ORG_ID> --page 2 --page-size 50
 
 `<ORG_ID>` is positional (`orgId`). Lists all files across all projects in the organization.
 
+### Search Member Directory
+
+```bash
+$CLI --compact orgs directory <ORG_ID> --query "ada"
+```
+
+Look up fellow organization members by name or email substring — this is how you find the numeric `userId` needed by `files share` / `folders share`. `<ORG_ID>` is positional; `--query` needs at least 2 characters. Any member can use it.
+
 ### Set Default Organization
 
 ```bash
@@ -256,6 +264,7 @@ Destructive — confirm with user first.
 | `orgs remove-member` | `elnora_orgs_removeMember` |
 | `orgs billing` | `elnora_orgs_billing` |
 | `orgs files` | `elnora_orgs_files` |
+| `orgs directory` | `elnora_orgs_directory` |
 | `orgs set-default` | `elnora_orgs_setDefault` |
 | `orgs set-stripe` | `elnora_orgs_setStripe` |
 | `orgs list-all` | `elnora_orgs_listAll` |

--- a/src/commands/files/index.ts
+++ b/src/commands/files/index.ts
@@ -9,9 +9,13 @@ import { filesDownload } from "./download.js";
 import { filesFork } from "./fork.js";
 import { filesGet } from "./get.js";
 import { filesList } from "./list.js";
+import { filesMove } from "./move.js";
 import { filesPromote } from "./promote.js";
 import { filesRestore } from "./restore.js";
 import { filesSearchContent } from "./search-content.js";
+import { filesShare } from "./share.js";
+import { filesShares } from "./shares.js";
+import { filesUnshare } from "./unshare.js";
 import { filesUpdate } from "./update.js";
 import { filesUpload } from "./upload.js";
 import { filesUploadBatch } from "./upload-batch.js";
@@ -40,6 +44,10 @@ export function registerFileCommands(): ElnoraCommand[] {
 		filesWorkingCopy,
 		filesCommit,
 		filesSearchContent,
+		filesMove,
+		filesShare,
+		filesUnshare,
+		filesShares,
 	];
 }
 
@@ -54,9 +62,13 @@ export {
 	filesFork,
 	filesGet,
 	filesList,
+	filesMove,
 	filesPromote,
 	filesRestore,
 	filesSearchContent,
+	filesShare,
+	filesShares,
+	filesUnshare,
 	filesUpdate,
 	filesUpload,
 	filesUploadBatch,

--- a/src/commands/files/move.ts
+++ b/src/commands/files/move.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	fileId: z.string().uuid().describe("File ID to move"),
+	parentFolderId: z.string().uuid().describe("Destination Knowledge Base folder ID"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const filesMove: ElnoraCommand<Input> = {
+	name: "files.move",
+	group: "files",
+	description: "Move a file to a different Knowledge Base folder",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { idempotentHint: true },
+
+	async execute(input, ctx) {
+		return ctx.client.patch(
+			"file_move",
+			{ parentFolderId: input.parentFolderId },
+			{ pathParams: { id: input.fileId } },
+		);
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/files/share.ts
+++ b/src/commands/files/share.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import { ValidationError } from "../../lib/errors.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	fileId: z.string().uuid().describe("File ID to share"),
+	userId: z.number().int().positive().optional().describe("User ID to share with (omit when using --org-wide)"),
+	orgWide: z.boolean().default(false).describe("Share with everyone in the organization"),
+	role: z.enum(["viewer", "editor", "admin"]).default("editor").describe("Access role to grant"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const filesShare: ElnoraCommand<Input> = {
+	name: "files.share",
+	group: "files",
+	description: "Share a file with a user or the whole organization (default role: editor)",
+	inputSchema,
+	outputSchema: z.any(),
+
+	async execute(input, ctx) {
+		// Exactly one principal: a specific user OR the whole org (teams are not available yet).
+		if (input.orgWide === (input.userId !== undefined)) {
+			throw new ValidationError(
+				"Specify exactly one recipient.",
+				"Pass either --user-id <id> or --org-wide (not both, and not neither).",
+			);
+		}
+		const body = input.orgWide ? { isOrgWide: true, role: input.role } : { userId: input.userId, role: input.role };
+		return ctx.client.post("file_share", body, { pathParams: { id: input.fileId } });
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/files/shares.ts
+++ b/src/commands/files/shares.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	fileId: z.string().uuid().describe("File ID"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const filesShares: ElnoraCommand<Input> = {
+	name: "files.shares",
+	group: "files",
+	description: "List the current shares on a file",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { readOnlyHint: true },
+
+	async execute(input, ctx) {
+		return ctx.client.get("file_shares", { pathParams: { id: input.fileId } });
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/files/unshare.ts
+++ b/src/commands/files/unshare.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	fileId: z.string().uuid().describe("File ID"),
+	aceId: z.string().uuid().describe("Share (ACE) ID to revoke"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const filesUnshare: ElnoraCommand<Input> = {
+	name: "files.unshare",
+	group: "files",
+	description: "Revoke a file share by its ACE id",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { destructiveHint: true, idempotentHint: true },
+
+	async execute(input, ctx) {
+		await ctx.client.del("file_share_ace", {
+			pathParams: { id: input.fileId, aceId: input.aceId },
+		});
+		return { revoked: true, fileId: input.fileId, aceId: input.aceId };
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { aceId?: string }).aceId ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/folders/index.ts
+++ b/src/commands/folders/index.ts
@@ -8,6 +8,9 @@ import { foldersList } from "./list.js";
 import { foldersMove } from "./move.js";
 import { foldersRename } from "./rename.js";
 import { foldersRoots } from "./roots.js";
+import { foldersShare } from "./share.js";
+import { foldersShares } from "./shares.js";
+import { foldersUnshare } from "./unshare.js";
 
 export function registerFolderCommands(): ElnoraCommand[] {
 	return [
@@ -20,6 +23,9 @@ export function registerFolderCommands(): ElnoraCommand[] {
 		foldersRename,
 		foldersMove,
 		foldersDelete,
+		foldersShare,
+		foldersUnshare,
+		foldersShares,
 	];
 }
 
@@ -33,4 +39,7 @@ export {
 	foldersMove,
 	foldersRename,
 	foldersRoots,
+	foldersShare,
+	foldersShares,
+	foldersUnshare,
 };

--- a/src/commands/folders/share.ts
+++ b/src/commands/folders/share.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import { ValidationError } from "../../lib/errors.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	folderId: z.string().uuid().describe("Folder ID to share"),
+	userId: z.number().int().positive().optional().describe("User ID to share with (omit when using --org-wide)"),
+	orgWide: z.boolean().default(false).describe("Share with everyone in the organization"),
+	role: z.enum(["viewer", "editor", "admin"]).default("editor").describe("Access role to grant"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const foldersShare: ElnoraCommand<Input> = {
+	name: "folders.share",
+	group: "folders",
+	description: "Share a folder with a user or the whole organization (default role: editor)",
+	inputSchema,
+	outputSchema: z.any(),
+
+	async execute(input, ctx) {
+		// Exactly one principal: a specific user OR the whole org (teams are not available yet).
+		if (input.orgWide === (input.userId !== undefined)) {
+			throw new ValidationError(
+				"Specify exactly one recipient.",
+				"Pass either --user-id <id> or --org-wide (not both, and not neither).",
+			);
+		}
+		const body = input.orgWide ? { isOrgWide: true, role: input.role } : { userId: input.userId, role: input.role };
+		return ctx.client.post("folder_share", body, { pathParams: { id: input.folderId } });
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/folders/shares.ts
+++ b/src/commands/folders/shares.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	folderId: z.string().uuid().describe("Folder ID"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const foldersShares: ElnoraCommand<Input> = {
+	name: "folders.shares",
+	group: "folders",
+	description: "List the current shares on a folder",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { readOnlyHint: true },
+
+	async execute(input, ctx) {
+		return ctx.client.get("folder_shares", { pathParams: { id: input.folderId } });
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/folders/unshare.ts
+++ b/src/commands/folders/unshare.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	folderId: z.string().uuid().describe("Folder ID"),
+	aceId: z.string().uuid().describe("Share (ACE) ID to revoke"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const foldersUnshare: ElnoraCommand<Input> = {
+	name: "folders.unshare",
+	group: "folders",
+	description: "Revoke a folder share by its ACE id",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { destructiveHint: true, idempotentHint: true },
+
+	async execute(input, ctx) {
+		await ctx.client.del("folder_share_ace", {
+			pathParams: { id: input.folderId, aceId: input.aceId },
+		});
+		return { revoked: true, folderId: input.folderId, aceId: input.aceId };
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { aceId?: string }).aceId ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/orgs/directory.ts
+++ b/src/commands/orgs/directory.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	orgId: z.string().uuid().describe("Organization ID"),
+	query: z.string().min(2).describe("Name or email substring to match (minimum 2 characters)"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const orgsDirectory: ElnoraCommand<Input> = {
+	name: "orgs.directory",
+	group: "orgs",
+	description: "Search organization members by name or email (Share-modal typeahead)",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { readOnlyHint: true },
+
+	async execute(input, ctx) {
+		return ctx.client.get("org_member_directory", {
+			pathParams: { orgId: input.orgId },
+			queryParams: { q: input.query },
+		});
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/orgs/index.ts
+++ b/src/commands/orgs/index.ts
@@ -4,6 +4,7 @@ import { orgsBilling } from "./billing.js";
 import { orgsCancelInvite } from "./cancel-invite.js";
 import { orgsCreate } from "./create.js";
 import { orgsDelete } from "./delete.js";
+import { orgsDirectory } from "./directory.js";
 import { orgsFiles } from "./files.js";
 import { orgsGet } from "./get.js";
 import { orgsInvitationInfo } from "./invitation-info.js";
@@ -40,6 +41,7 @@ export function registerOrgCommands(): ElnoraCommand[] {
 		orgsAcceptInvite,
 		orgsFiles,
 		orgsListAll,
+		orgsDirectory,
 	];
 }
 
@@ -49,6 +51,7 @@ export {
 	orgsCancelInvite,
 	orgsCreate,
 	orgsDelete,
+	orgsDirectory,
 	orgsFiles,
 	orgsGet,
 	orgsInvitationInfo,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -49,6 +49,11 @@ export const ENDPOINTS: Record<string, string> = {
 	file_working_copy: "/files/{id}/working-copy",
 	file_commit: "/files/{id}/commit",
 	file_upload_batch: "/files/upload/batch",
+	file_move: "/files/{id}/move",
+	// Per-file sharing (KB Access V2)
+	file_share: "/files/{id}/share",
+	file_share_ace: "/files/{id}/share/{aceId}",
+	file_shares: "/files/{id}/shares",
 	// Folders (closure-table Knowledge Base — the `folder`/`folder_move` paths are shared with the
 	// legacy controller; the KB read/mutation verbs are distinguished by HTTP method at the call site)
 	folder: "/folders/{id}",
@@ -57,6 +62,10 @@ export const ENDPOINTS: Record<string, string> = {
 	folder_roots: "/folders/roots",
 	folder_children: "/folders/{id}/children",
 	folder_files: "/folders/{id}/files",
+	// Per-folder sharing (KB Access V2)
+	folder_share: "/folders/{id}/share",
+	folder_share_ace: "/folders/{id}/share/{aceId}",
+	folder_shares: "/folders/{id}/shares",
 	// Organizations
 	organizations: "/organizations",
 	organization: "/organizations/{id}",
@@ -68,6 +77,7 @@ export const ENDPOINTS: Record<string, string> = {
 	organization_set_default: "/organizations/{id}/set-default",
 	organizations_all: "/organizations/all",
 	org_files: "/organizations/{orgId}/files",
+	org_member_directory: "/organizations/{orgId}/members/directory",
 	// Organization invitations
 	org_invitations: "/organizations/{orgId}/invitations",
 	org_invitation: "/organizations/{orgId}/invitations/{invId}",


### PR DESCRIPTION
## Summary

Adds the **KB Access V2 sharing commands**, mirroring the new elnora-mcp-server tools, so CLI callers can manage per-file and per-folder access, move files, and find members to share with.

| Command | Calls |
|---|---|
| `files share <file-id> [--user-id N \| --org-wide] [--role]` | `POST /files/{id}/share` |
| `files unshare <file-id> <ace-id>` | `DELETE /files/{id}/share/{aceId}` |
| `files shares <file-id>` | `GET /files/{id}/shares` |
| `files move <file-id> <parent-folder-id>` | `PATCH /files/{id}/move` |
| `folders share <folder-id> [--user-id N \| --org-wide] [--role]` | `POST /folders/{id}/share` |
| `folders unshare <folder-id> <ace-id>` | `DELETE /folders/{id}/share/{aceId}` |
| `folders shares <folder-id>` | `GET /folders/{id}/shares` |
| `orgs directory <org-id> --query <term>` | `GET /organizations/{id}/members/directory` |

`share` grants a `viewer` / `editor` (default) / `admin` role to **exactly one** recipient — `--user-id` **or** `--org-wide` — validated client-side before any request. Use `orgs directory` to find a member's numeric user id.

## Changes

- `src/commands/{files,folders,orgs}/*` — 8 new commands + registration
- `src/lib/config.ts` — endpoint keys
- `skills/elnora-{files,folders,orgs}/SKILL.md` — command docs + MCP tool-name mapping
- per-command tests (files 23 / folders 12 / orgs 20 registered)

## Testing

- `pnpm typecheck` / `pnpm lint` clean, `pnpm test` — 708 passing
- `pnpm audit:mcp-parity` — 102/102, 0 mismatches
- Verified end-to-end against a local backend (share → list → unshare, move, directory typeahead)

## Merge order

The MCP-parity check compares against `elnora-mcp-server@main` and stays red until the paired MCP PR merges — please merge that one first, then re-run this check.