### PR TITLE
feat: KB folder-mutation repoint + review queue, auto-tidy & task-lifecycle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ elnora setup
 
 This auto-detects which tools you have installed and configures them:
 
-- **Claude Code** — registers the `elnora-plugins` marketplace and enables 9 skills (`elnora-tasks`, `elnora-projects`, `elnora-files`, etc.) so you can use natural language.
+- **Claude Code** — registers the `elnora-plugins` marketplace and enables 10 skills (`elnora-tasks`, `elnora-projects`, `elnora-files`, etc.) so you can use natural language.
 - **Cursor / VS Code / Codex** — writes an MCP server config pointing at `https://mcp.elnora.ai/mcp` with your API key.
 
 Target a specific tool: `elnora setup claude` · `elnora setup cursor` · `elnora setup vscode` · `elnora setup codex`.

--- a/__tests__/commands/doctor.test.ts
+++ b/__tests__/commands/doctor.test.ts
@@ -135,6 +135,7 @@ describe("elnora doctor", () => {
 			"elnora-orgs",
 			"elnora-platform",
 			"elnora-projects",
+			"elnora-review",
 			"elnora-search",
 			"elnora-tasks",
 		]) {
@@ -156,7 +157,7 @@ describe("elnora doctor", () => {
 		const output = capture.getOutput();
 		// Verify the Claude Code section reports clean results
 		expect(output).toMatch(/✓[^\n]*Plugin enabled.*elnora@elnora-plugins/);
-		expect(output).toMatch(/✓[^\n]*Skills installed.*9 skills/);
+		expect(output).toMatch(/✓[^\n]*Skills installed.*10 skills/);
 		// Split the Plugin version check into a structure match + a literal
 		// substring check so we don't have to build a regex from VERSION
 		// (avoids regex-escaping pitfalls flagged by CodeQL).
@@ -195,6 +196,7 @@ describe("elnora doctor", () => {
 			"elnora-orgs",
 			"elnora-platform",
 			"elnora-projects",
+			"elnora-review",
 			"elnora-search",
 			"elnora-tasks",
 		]) {

--- a/__tests__/commands/folders/folders.test.ts
+++ b/__tests__/commands/folders/folders.test.ts
@@ -23,6 +23,7 @@ const ACE_ID = "e5f6a7b8-c9d0-4e1f-9a2b-3c4d5e6f7a8b";
 function mockContext(overrides?: {
 	getResult?: unknown;
 	postResult?: unknown;
+	patchResult?: unknown;
 	putResult?: unknown;
 	delResult?: unknown;
 }): CommandContext {
@@ -30,7 +31,7 @@ function mockContext(overrides?: {
 		client: {
 			get: vi.fn().mockResolvedValue(overrides?.getResult ?? {}),
 			post: vi.fn().mockResolvedValue(overrides?.postResult ?? {}),
-			patch: vi.fn().mockResolvedValue({}),
+			patch: vi.fn().mockResolvedValue(overrides?.patchResult ?? {}),
 			put: vi.fn().mockResolvedValue(overrides?.putResult ?? {}),
 			del: vi.fn().mockResolvedValue(overrides?.delResult ?? undefined),
 		} as unknown as CommandContext["client"],
@@ -79,32 +80,30 @@ describe("folders.create", () => {
 		expect(foldersCreate.group).toBe("folders");
 	});
 
-	test("requires projectId and name", () => {
+	test("requires name; projectId is no longer required", () => {
 		expect(() => foldersCreate.inputSchema.parse({})).toThrow();
-		expect(() => foldersCreate.inputSchema.parse({ projectId: PROJECT_ID })).toThrow();
-		expect(foldersCreate.inputSchema.parse({ projectId: PROJECT_ID, name: "Folder" })).toEqual({
-			projectId: PROJECT_ID,
-			name: "Folder",
-		});
+		expect(foldersCreate.inputSchema.parse({ name: "Folder" })).toMatchObject({ name: "Folder" });
 	});
 
-	test("calls POST /projects/{id}/folders", async () => {
+	test("POSTs to the KB folder collection by default", async () => {
 		const ctx = mockContext({ postResult: { id: FOLDER_ID, name: "New" } });
-		const result = await foldersCreate.execute({ projectId: PROJECT_ID, name: "New" }, ctx);
-		expect(ctx.client.post).toHaveBeenCalledWith(
-			"project_folders",
-			{ name: "New" },
-			{ pathParams: { id: PROJECT_ID } },
-		);
+		const result = await foldersCreate.execute({ name: "New" }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith("folder_create", { name: "New" });
 		expect(result).toEqual({ id: FOLDER_ID, name: "New" });
 	});
 
-	test("includes parentId when provided", async () => {
+	test("includes parentFolderId when parentId is provided", async () => {
 		const ctx = mockContext({ postResult: { id: FOLDER_ID } });
-		await foldersCreate.execute({ projectId: PROJECT_ID, name: "Sub", parentId: PARENT_ID }, ctx);
+		await foldersCreate.execute({ name: "Sub", parentId: PARENT_ID }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith("folder_create", { name: "Sub", parentFolderId: PARENT_ID });
+	});
+
+	test("uses the legacy project endpoint when --project is set", async () => {
+		const ctx = mockContext({ postResult: { id: FOLDER_ID } });
+		await foldersCreate.execute({ name: "Leg", project: PROJECT_ID }, ctx);
 		expect(ctx.client.post).toHaveBeenCalledWith(
 			"project_folders",
-			{ name: "Sub", parentId: PARENT_ID },
+			{ name: "Leg" },
 			{ pathParams: { id: PROJECT_ID } },
 		);
 	});
@@ -124,11 +123,17 @@ describe("folders.rename", () => {
 		expect(foldersRename.annotations?.idempotentHint).toBe(true);
 	});
 
-	test("calls PUT /folders/{id}", async () => {
-		const ctx = mockContext({ putResult: { id: FOLDER_ID, name: "Renamed" } });
-		const result = await foldersRename.execute({ folderId: FOLDER_ID, name: "Renamed" }, ctx);
-		expect(ctx.client.put).toHaveBeenCalledWith("folder", { name: "Renamed" }, { pathParams: { id: FOLDER_ID } });
+	test("PATCHes the KB folder by default", async () => {
+		const ctx = mockContext({ patchResult: { id: FOLDER_ID, name: "Renamed" } });
+		const result = await foldersRename.execute({ folderId: FOLDER_ID, name: "Renamed", legacy: false }, ctx);
+		expect(ctx.client.patch).toHaveBeenCalledWith("folder", { name: "Renamed" }, { pathParams: { id: FOLDER_ID } });
 		expect(result).toEqual({ id: FOLDER_ID, name: "Renamed" });
+	});
+
+	test("PUTs the legacy folder when --legacy is set", async () => {
+		const ctx = mockContext({ putResult: { id: FOLDER_ID } });
+		await foldersRename.execute({ folderId: FOLDER_ID, name: "Renamed", legacy: true }, ctx);
+		expect(ctx.client.put).toHaveBeenCalledWith("folder", { name: "Renamed" }, { pathParams: { id: FOLDER_ID } });
 	});
 });
 
@@ -142,27 +147,47 @@ describe("folders.move", () => {
 		expect(foldersMove.group).toBe("folders");
 	});
 
-	test("sends null parentId when 'root' is provided", async () => {
-		const ctx = mockContext({ putResult: { id: FOLDER_ID } });
-		await foldersMove.execute({ folderId: FOLDER_ID, parentId: "root" }, ctx);
-		expect(ctx.client.put).toHaveBeenCalledWith("folder_move", { parentId: null }, { pathParams: { id: FOLDER_ID } });
+	test("PATCHes folder_move with parentFolderId for a UUID parent", async () => {
+		const ctx = mockContext({ patchResult: { id: FOLDER_ID } });
+		await foldersMove.execute({ folderId: FOLDER_ID, parentId: PARENT_ID, legacy: false }, ctx);
+		expect(ctx.client.patch).toHaveBeenCalledWith(
+			"folder_move",
+			{ parentFolderId: PARENT_ID },
+			{ pathParams: { id: FOLDER_ID } },
+		);
 	});
 
-	test("sends UUID parentId when valid UUID is provided", async () => {
+	test("PATCHes folder with moveToRoot when 'root' is provided", async () => {
+		const ctx = mockContext({ patchResult: { id: FOLDER_ID } });
+		await foldersMove.execute({ folderId: FOLDER_ID, parentId: "root", legacy: false }, ctx);
+		expect(ctx.client.patch).toHaveBeenCalledWith("folder", { moveToRoot: true }, { pathParams: { id: FOLDER_ID } });
+	});
+
+	test("PUTs legacy folder_move with newParentFolderId when --legacy is set", async () => {
 		const ctx = mockContext({ putResult: { id: FOLDER_ID } });
-		await foldersMove.execute({ folderId: FOLDER_ID, parentId: PARENT_ID }, ctx);
+		await foldersMove.execute({ folderId: FOLDER_ID, parentId: PARENT_ID, legacy: true }, ctx);
 		expect(ctx.client.put).toHaveBeenCalledWith(
 			"folder_move",
-			{ parentId: PARENT_ID },
+			{ newParentFolderId: PARENT_ID },
+			{ pathParams: { id: FOLDER_ID } },
+		);
+	});
+
+	test("legacy move to 'root' sends null newParentFolderId", async () => {
+		const ctx = mockContext({ putResult: { id: FOLDER_ID } });
+		await foldersMove.execute({ folderId: FOLDER_ID, parentId: "root", legacy: true }, ctx);
+		expect(ctx.client.put).toHaveBeenCalledWith(
+			"folder_move",
+			{ newParentFolderId: null },
 			{ pathParams: { id: FOLDER_ID } },
 		);
 	});
 
 	test("throws ValidationError for invalid parent value", async () => {
 		const ctx = mockContext();
-		await expect(foldersMove.execute({ folderId: FOLDER_ID, parentId: "invalid-string" }, ctx)).rejects.toThrow(
-			ValidationError,
-		);
+		await expect(
+			foldersMove.execute({ folderId: FOLDER_ID, parentId: "invalid-string", legacy: false }, ctx),
+		).rejects.toThrow(ValidationError);
 	});
 });
 
@@ -180,17 +205,22 @@ describe("folders.delete", () => {
 		expect(foldersDelete.annotations?.destructiveHint).toBe(true);
 	});
 
-	test("calls DELETE /folders/{id} and returns deleted result", async () => {
+	test("archives the KB folder by default", async () => {
 		const ctx = mockContext();
-		const result = await foldersDelete.execute({ folderId: FOLDER_ID }, ctx);
-		expect(ctx.client.del).toHaveBeenCalledWith("folder", {
-			pathParams: { id: FOLDER_ID },
-		});
+		const result = await foldersDelete.execute({ folderId: FOLDER_ID, legacy: false }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith("folder_archive", {}, { pathParams: { id: FOLDER_ID } });
+		expect(result).toEqual({ archived: true, folderId: FOLDER_ID });
+	});
+
+	test("hard-deletes the legacy folder when --legacy is set", async () => {
+		const ctx = mockContext();
+		const result = await foldersDelete.execute({ folderId: FOLDER_ID, legacy: true }, ctx);
+		expect(ctx.client.del).toHaveBeenCalledWith("folder", { pathParams: { id: FOLDER_ID } });
 		expect(result).toEqual({ deleted: true, folderId: FOLDER_ID });
 	});
 
 	test("formatOutput compact returns folderId", () => {
-		expect(foldersDelete.formatOutput({ deleted: true, folderId: FOLDER_ID }, "compact")).toBe(FOLDER_ID);
+		expect(foldersDelete.formatOutput({ archived: true, folderId: FOLDER_ID }, "compact")).toBe(FOLDER_ID);
 	});
 });
 

--- a/__tests__/commands/orgs/orgs.test.ts
+++ b/__tests__/commands/orgs/orgs.test.ts
@@ -16,6 +16,7 @@ import { orgsListAll } from "../../../src/commands/orgs/list-all.js";
 import { orgsMembers } from "../../../src/commands/orgs/members.js";
 import { orgsRemoveMember } from "../../../src/commands/orgs/remove-member.js";
 import { orgsResendInvite } from "../../../src/commands/orgs/resend-invite.js";
+import { orgsSetAutotidy } from "../../../src/commands/orgs/set-autotidy.js";
 import { orgsSetDefault } from "../../../src/commands/orgs/set-default.js";
 import { orgsSetStripe } from "../../../src/commands/orgs/set-stripe.js";
 import { orgsUpdate } from "../../../src/commands/orgs/update.js";
@@ -587,13 +588,39 @@ describe("orgs.directory", () => {
 });
 
 // ---------------------------------------------------------------------------
+// orgs.setAutotidy
+// ---------------------------------------------------------------------------
+
+describe("orgs.setAutotidy", () => {
+	test("PATCHes kb-autotidy with enabled true", async () => {
+		const ctx = mockContext({ patchResult: { kbAutotidyEnabled: true } });
+		await orgsSetAutotidy.execute({ orgId: ORG_ID, enabled: true }, ctx);
+		expect(ctx.client.patch).toHaveBeenCalledWith(
+			"org_kb_autotidy",
+			{ enabled: true },
+			{ pathParams: { orgId: ORG_ID } },
+		);
+	});
+
+	test("PATCHes kb-autotidy with enabled false", async () => {
+		const ctx = mockContext({ patchResult: { kbAutotidyEnabled: false } });
+		await orgsSetAutotidy.execute({ orgId: ORG_ID, enabled: false }, ctx);
+		expect(ctx.client.patch).toHaveBeenCalledWith(
+			"org_kb_autotidy",
+			{ enabled: false },
+			{ pathParams: { orgId: ORG_ID } },
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // registerOrgCommands
 // ---------------------------------------------------------------------------
 
 describe("registerOrgCommands", () => {
-	test("returns all 20 org commands", () => {
+	test("returns all 21 org commands", () => {
 		const commands = registerOrgCommands();
-		expect(commands).toHaveLength(20);
+		expect(commands).toHaveLength(21);
 	});
 
 	test("all commands belong to orgs group", () => {

--- a/__tests__/commands/review/review.test.ts
+++ b/__tests__/commands/review/review.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test, vi } from "vitest";
+import { reviewApprove } from "../../../src/commands/review/approve.js";
+import { registerReviewCommands } from "../../../src/commands/review/index.js";
+import { reviewList } from "../../../src/commands/review/list.js";
+import { reviewReject } from "../../../src/commands/review/reject.js";
+import type { CommandContext } from "../../../src/core/command.js";
+
+const ITEM_ID = "d5c4b3a2-f6e5-4b7a-9d8c-1f0e2a3b4c5d";
+
+function mockContext(overrides?: { getResult?: unknown; postResult?: unknown }): CommandContext {
+	return {
+		client: {
+			get: vi.fn().mockResolvedValue(overrides?.getResult ?? {}),
+			post: vi.fn().mockResolvedValue(overrides?.postResult ?? {}),
+			patch: vi.fn().mockResolvedValue({}),
+			put: vi.fn().mockResolvedValue({}),
+			del: vi.fn().mockResolvedValue(undefined),
+		} as unknown as CommandContext["client"],
+		profileName: "default",
+		mode: "cli",
+		output: { format: "json", compact: false },
+	};
+}
+
+describe("review.list", () => {
+	test("is read-only and defaults to pending", async () => {
+		expect(reviewList.annotations?.readOnlyHint).toBe(true);
+		const ctx = mockContext({ getResult: [] });
+		await reviewList.execute({ status: "pending" }, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("kb_review_items", { queryParams: { status: "pending" } });
+	});
+
+	test("'all' maps to an empty status filter", async () => {
+		const ctx = mockContext({ getResult: [] });
+		await reviewList.execute({ status: "all" }, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("kb_review_items", { queryParams: { status: "" } });
+	});
+});
+
+describe("review.approve", () => {
+	test("POSTs the approve endpoint", async () => {
+		const ctx = mockContext({ postResult: { id: ITEM_ID } });
+		await reviewApprove.execute({ itemId: ITEM_ID }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith("kb_review_approve", {}, { pathParams: { id: ITEM_ID } });
+	});
+});
+
+describe("review.reject", () => {
+	test("POSTs the reject endpoint", async () => {
+		const ctx = mockContext({ postResult: { id: ITEM_ID } });
+		await reviewReject.execute({ itemId: ITEM_ID }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith("kb_review_reject", {}, { pathParams: { id: ITEM_ID } });
+	});
+});
+
+describe("registerReviewCommands", () => {
+	test("returns all 3 review commands in the review group", () => {
+		const commands = registerReviewCommands();
+		expect(commands).toHaveLength(3);
+		for (const cmd of commands) {
+			expect(cmd.group).toBe("review");
+			expect(cmd.name).toMatch(/^review\./);
+		}
+	});
+});

--- a/__tests__/commands/tasks/tasks.test.ts
+++ b/__tests__/commands/tasks/tasks.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test, vi } from "vitest";
 import { tasksArchive } from "../../../src/commands/tasks/archive.js";
+import { tasksAttachmentContent } from "../../../src/commands/tasks/attachment-content.js";
+import { tasksAttachments } from "../../../src/commands/tasks/attachments.js";
 import { tasksCreate } from "../../../src/commands/tasks/create.js";
 import { tasksGet } from "../../../src/commands/tasks/get.js";
 import { registerTaskCommands } from "../../../src/commands/tasks/index.js";
 import { tasksList } from "../../../src/commands/tasks/list.js";
 import { tasksMessages } from "../../../src/commands/tasks/messages.js";
 import { tasksSend } from "../../../src/commands/tasks/send.js";
+import { tasksUnarchive } from "../../../src/commands/tasks/unarchive.js";
 import { tasksUpdate } from "../../../src/commands/tasks/update.js";
 import type { CommandContext } from "../../../src/core/command.js";
 import { ValidationError } from "../../../src/lib/errors.js";
@@ -78,6 +81,14 @@ describe("tasks.list", () => {
 
 	test("rejects invalid project UUID", () => {
 		expect(() => tasksList.inputSchema.parse({ project: "not-uuid" })).toThrow();
+	});
+
+	test("includes status in queryParams when provided", async () => {
+		const ctx = mockContext({ getResult: { items: [] } });
+		await tasksList.execute({ status: "archived", page: 1, pageSize: 25 }, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("tasks", {
+			queryParams: { page: 1, pageSize: 25, status: "archived" },
+		});
 	});
 
 	test("formatOutput compact returns id or JSON", () => {
@@ -388,13 +399,45 @@ describe("tasks.archive", () => {
 });
 
 // ---------------------------------------------------------------------------
+// tasks.unarchive / attachments / attachmentContent
+// ---------------------------------------------------------------------------
+
+describe("tasks.unarchive", () => {
+	test("POSTs the unarchive endpoint and returns unarchived", async () => {
+		const ctx = mockContext();
+		const result = await tasksUnarchive.execute({ taskId: TASK_ID }, ctx);
+		expect(ctx.client.post).toHaveBeenCalledWith("task_unarchive", {}, { pathParams: { id: TASK_ID } });
+		expect(result).toEqual({ unarchived: true, taskId: TASK_ID });
+	});
+});
+
+describe("tasks.attachments", () => {
+	test("is read-only and GETs the attachments list", async () => {
+		expect(tasksAttachments.annotations?.readOnlyHint).toBe(true);
+		const ctx = mockContext({ getResult: [] });
+		await tasksAttachments.execute({ taskId: TASK_ID }, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("task_attachments", { pathParams: { id: TASK_ID } });
+	});
+});
+
+describe("tasks.attachmentContent", () => {
+	test("GETs the attachment content with both path params", async () => {
+		const ctx = mockContext({ getResult: { content: "hi" } });
+		await tasksAttachmentContent.execute({ taskId: TASK_ID, attachmentId: FILE_ID_1 }, ctx);
+		expect(ctx.client.get).toHaveBeenCalledWith("task_attachment_content", {
+			pathParams: { id: TASK_ID, aid: FILE_ID_1 },
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
 // registerTaskCommands
 // ---------------------------------------------------------------------------
 
 describe("registerTaskCommands", () => {
-	test("returns all 7 task commands", () => {
+	test("returns all 10 task commands", () => {
 		const commands = registerTaskCommands();
-		expect(commands).toHaveLength(7);
+		expect(commands).toHaveLength(10);
 	});
 
 	test("all commands belong to tasks group", () => {

--- a/scripts/gen-docs-reference.ts
+++ b/scripts/gen-docs-reference.ts
@@ -186,6 +186,7 @@ const GROUP_BLURB: Record<string, string> = {
 	orgs: "Manage organizations, members, and invitations.",
 	projects: "Create and manage projects and their members.",
 	protocols: "Generate and optimize bioprotocols.",
+	review: "Approve or reject Knowledge Base auto-tidy proposals.",
 	search: "Search across your knowledge base and content.",
 	tasks: "Drive the Elnora agent — create tasks and exchange messages.",
 };

--- a/skills/elnora-folders/SKILL.md
+++ b/skills/elnora-folders/SKILL.md
@@ -57,31 +57,30 @@ CLI="elnora"
 
 ## Commands
 
-### List Folders
-
-```bash
-$CLI --compact folders list <PROJECT_ID>
-```
-
-`<PROJECT_ID>` is positional (`projectId`). Returns the folder tree for the project.
+> **Knowledge Base by default.** `create` / `rename` / `move` / `delete` operate on the
+> Knowledge Base (the current folder model — same tree as `folders roots`/`children`). The
+> old project-scoped folders are legacy; reach them with `--project` (create) or `--legacy`
+> (rename/move/delete).
 
 ### Create Folder
 
 ```bash
-$CLI --compact folders create <PROJECT_ID> --name "Experiments"
-$CLI --compact folders create <PROJECT_ID> --name "Sub Folder" --parent-id <PARENT_FOLDER_ID>
+$CLI --compact folders create --name "Experiments"
+$CLI --compact folders create --name "Sub Folder" --parent-id <PARENT_FOLDER_ID>
+$CLI --compact folders create --name "Legacy" --project <PROJECT_ID>   # legacy project folder
 ```
 
 | Flag/Arg | Required | Notes |
 |----------|----------|-------|
-| `<PROJECT_ID>` | Yes | Positional — project UUID |
 | `--name` | Yes | Folder name |
-| `--parent-id` | No | Parent folder UUID for nesting (optional, so it's a flag) |
+| `--parent-id` | No | Parent folder UUID for nesting |
+| `--project` | No | Legacy: create a project-scoped folder in this project instead |
 
 ### Rename Folder
 
 ```bash
 $CLI --compact folders rename <FOLDER_ID> --name "New Name"
+$CLI --compact folders rename <FOLDER_ID> --name "New Name" --legacy   # a legacy project folder
 ```
 
 ### Move Folder
@@ -89,18 +88,28 @@ $CLI --compact folders rename <FOLDER_ID> --name "New Name"
 ```bash
 $CLI --compact folders move <FOLDER_ID> <NEW_PARENT_ID>
 $CLI --compact folders move <FOLDER_ID> root
+$CLI --compact folders move <FOLDER_ID> <NEW_PARENT_ID> --legacy
 ```
 
-Both `<FOLDER_ID>` and `<NEW_PARENT_ID>` are positional (`folderId` and `parentId`). Use `root` to move to the project root level.
+Both `<FOLDER_ID>` and `<NEW_PARENT_ID>` are positional (`folderId` and `parentId`). Use `root` to move to the top level.
 
 ### Delete Folder
 
 ```bash
-$CLI --compact folders delete <FOLDER_ID>
-# -> {"deleted":true,"folderId":"<UUID>"}
+$CLI --compact folders delete <FOLDER_ID>            # KB: archives the folder
+# -> {"archived":true,"folderId":"<UUID>"}
+$CLI --compact folders delete <FOLDER_ID> --legacy   # legacy: hard-deletes a project folder
 ```
 
 Destructive — confirm with user before running.
+
+### List Folders (legacy)
+
+```bash
+$CLI --compact folders list <PROJECT_ID>
+```
+
+Legacy project-scoped folder tree. `<PROJECT_ID>` is positional. For the Knowledge Base, browse with `folders roots` / `folders children` instead.
 
 ### Share a Folder
 
@@ -137,18 +146,19 @@ $CLI --compact folders unshare <FOLDER_ID> <ACE_ID>  # revoke one share
 
 ## Agent Recipes
 
-**Set up folder structure for a new project:**
+**Set up a Knowledge Base folder structure:**
 
 ```bash
-PROJECT="<PROJECT_ID>"
-$CLI --compact folders create "$PROJECT" --name "Protocols"
-$CLI --compact folders create "$PROJECT" --name "Data"
-$CLI --compact folders create "$PROJECT" --name "Reports"
+$CLI --compact folders create --name "Protocols"
+$CLI --compact folders create --name "Data"
+$CLI --compact folders create --name "Reports"
+# nest one under another with --parent-id <FOLDER_ID>
 ```
 
 **Move a file into a folder:**
 
 ```bash
-$CLI --compact folders list <PROJECT_ID>
-$CLI --compact files update <FILE_ID> --folder <FOLDER_ID>
+$CLI --compact folders roots                 # find the folder to move into
+$CLI --compact folders children <FOLDER_ID>
+$CLI --compact files move <FILE_ID> <FOLDER_ID>
 ```

--- a/skills/elnora-orgs/SKILL.md
+++ b/skills/elnora-orgs/SKILL.md
@@ -123,6 +123,15 @@ Look up fellow organization members by name or email substring — this is how y
 $CLI --compact orgs set-default <ORG_ID>
 ```
 
+### Set Knowledge Base Auto-Tidy
+
+```bash
+$CLI --compact orgs set-autotidy <ORG_ID> --enabled   # turn on
+$CLI --compact orgs set-autotidy <ORG_ID>             # turn off (omit --enabled)
+```
+
+Toggles KB auto-tidy for the org. When on, the agent proposes folder/file tidy-ups that land in the review queue (see the `elnora-review` skill).
+
 ### Set Stripe Customer ID (SystemAdmin)
 
 ```bash
@@ -265,6 +274,7 @@ Destructive — confirm with user first.
 | `orgs billing` | `elnora_orgs_billing` |
 | `orgs files` | `elnora_orgs_files` |
 | `orgs directory` | `elnora_orgs_directory` |
+| `orgs set-autotidy` | `elnora_orgs_setAutotidy` |
 | `orgs set-default` | `elnora_orgs_setDefault` |
 | `orgs set-stripe` | `elnora_orgs_setStripe` |
 | `orgs list-all` | `elnora_orgs_listAll` |

--- a/skills/elnora-review/SKILL.md
+++ b/skills/elnora-review/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: elnora-review
+description: >
+  This skill should be used when the user asks to "review the knowledge base",
+  "list review items", "KB review queue", "approve a review item", "reject a
+  review item", "auto-tidy proposals", "pending KB changes", or any task
+  involving the Elnora Platform Knowledge Base review queue.
+---
+
+# Elnora Knowledge Base Review
+
+Approve or reject the auto-tidy proposals in the Knowledge Base review queue.
+When KB auto-tidy is enabled for an organization (see `orgs set-autotidy` in the
+`elnora-orgs` skill), the agent proposes folder/file renames, moves, archives,
+and tags; those land here for a human to approve before they are applied.
+
+## Tool Access
+
+Elnora is available via two methods. Use whichever is configured.
+
+**Option A — CLI via Bash (preferred)**
+
+Run commands via your Bash/Shell tool as `elnora <group> <action> ...`. Verify with `elnora --version`. CLI uses ~5× fewer tokens than MCP.
+
+**Option B — MCP tools (when CLI isn't installed)**
+
+Look for tools prefixed `mcp__elnora__` in your available tools. Call them with structured parameters. See the "MCP Tool Names" table below for the mapping.
+
+**If neither is available, tell the user to install one:**
+
+- CLI: `curl -fsSL https://cli.elnora.ai/install.sh | bash` (macOS/Linux)
+  or `irm https://cli.elnora.ai/install.ps1 | iex` (Windows)
+- MCP: `claude mcp add elnora --transport http --scope user https://mcp.elnora.ai/mcp`
+  then `/mcp` to authenticate.
+
+**Never fabricate tool names.** Valid commands are in the Commands section; their MCP equivalents are in the MCP Tool Names table.
+
+## Invocation
+
+```bash
+CLI="elnora"
+```
+
+## Commands
+
+### List the Review Queue
+
+```bash
+$CLI --compact review list                 # pending items (default)
+$CLI --compact review list --status all    # every state
+$CLI --compact review list --status applied
+$CLI --compact review list --status rejected
+```
+
+Each item has an `id` (the review item ID) and a proposed change (rename / move / archive / tag) on a target folder or file. `--status` is `pending` (default), `applied`, `rejected`, or `all`.
+
+### Approve an Item
+
+```bash
+$CLI --compact review approve <ITEM_ID>
+```
+
+Applies the proposed change **as you** — you must have write access to the target, or the approve is rejected.
+
+### Reject an Item
+
+```bash
+$CLI --compact review reject <ITEM_ID>
+```
+
+Records the item as rejected; no change is applied.
+
+## MCP Tool Names
+
+| CLI command | MCP tool name |
+|-------------|---------------|
+| `review list` | `elnora_review_list` |
+| `review approve` | `elnora_review_approve` |
+| `review reject` | `elnora_review_reject` |
+
+## Agent Recipes
+
+**Approve every pending rename, review everything else:**
+
+```bash
+$CLI --compact review list --status pending
+# inspect each item, then for the ones to accept:
+$CLI --compact review approve <ITEM_ID>
+```

--- a/skills/elnora-tasks/SKILL.md
+++ b/skills/elnora-tasks/SKILL.md
@@ -89,11 +89,13 @@ $CLI --compact --fields "id,name" projects list
 
 ```bash
 $CLI --compact tasks list
+$CLI --compact tasks list --status archived     # only archived tasks
+$CLI --compact tasks list --status all
 $CLI --compact tasks list --project <PROJECT_ID>
 $CLI --compact tasks list --project <PROJECT_ID> --page 2 --page-size 50
 ```
 
-Pagination: `--page` (default 1), `--page-size` (default 25, max 100).
+`--status` is `active` (default — hides archived), `archived`, or `all`. Pagination: `--page` (default 1), `--page-size` (default 25, max 100).
 
 Response:
 
@@ -175,14 +177,23 @@ $CLI --compact tasks update <TASK_ID> --status completed
 
 Must provide at least one of `--title` or `--status`.
 
-### Archive Task
+### Archive / Unarchive Task
 
 ```bash
 $CLI --compact tasks archive <TASK_ID>
 # -> {"archived":true,"taskId":"<UUID>"}
+$CLI --compact tasks unarchive <TASK_ID>
+# -> {"unarchived":true,"taskId":"<UUID>"}
 ```
 
-Destructive — confirm with user before running.
+Archive is destructive-ish (hides the task) — confirm with user. Archived tasks are found with `tasks list --status archived` and restored with `tasks unarchive`.
+
+### Task Attachments
+
+```bash
+$CLI --compact tasks attachments <TASK_ID>                        # list attached files
+$CLI --compact tasks attachment-content <TASK_ID> <ATTACHMENT_ID>  # read one attachment
+```
 
 ## MCP Tool Names
 
@@ -197,6 +208,9 @@ All commands are auto-registered as MCP tools with the `elnora_` prefix:
 | `tasks messages` | `elnora_tasks_messages` |
 | `tasks update` | `elnora_tasks_update` |
 | `tasks archive` | `elnora_tasks_archive` |
+| `tasks unarchive` | `elnora_tasks_unarchive` |
+| `tasks attachments` | `elnora_tasks_attachments` |
+| `tasks attachment-content` | `elnora_tasks_attachmentContent` |
 
 MCP tools accept the same parameters as CLI flags (camelCase). `elnora_tasks_send` always waits for the full agent response.
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -25,6 +25,7 @@ const EXPECTED_SKILLS = [
 	"elnora-orgs",
 	"elnora-platform",
 	"elnora-projects",
+	"elnora-review",
 	"elnora-search",
 	"elnora-tasks",
 ];

--- a/src/commands/folders/create.ts
+++ b/src/commands/folders/create.ts
@@ -3,9 +3,13 @@ import type { ElnoraCommand } from "../../core/command.js";
 import type { OutputFormat } from "../../lib/output.js";
 
 const inputSchema = z.object({
-	projectId: z.string().uuid().describe("Project ID"),
 	name: z.string().min(1).describe("Folder name"),
-	parentId: z.string().uuid().optional().describe("Parent folder ID"),
+	parentId: z.string().uuid().optional().describe("Parent folder ID (for nesting)"),
+	project: z
+		.string()
+		.uuid()
+		.optional()
+		.describe("Legacy: create a project-scoped folder in this project instead of a Knowledge Base folder"),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -13,16 +17,19 @@ type Input = z.infer<typeof inputSchema>;
 export const foldersCreate: ElnoraCommand<Input> = {
 	name: "folders.create",
 	group: "folders",
-	description: "Create a new folder in a project",
+	description: "Create a Knowledge Base folder (or a legacy project folder when project is set)",
 	inputSchema,
 	outputSchema: z.any(),
 
 	async execute(input, ctx) {
+		// Both the KB (CreateFolderRequestDTO) and legacy (CreateFolderDTO) bodies use `parentFolderId`.
 		const body: Record<string, unknown> = { name: input.name };
-		if (input.parentId) body.parentId = input.parentId;
-		return ctx.client.post("project_folders", body, {
-			pathParams: { id: input.projectId },
-		});
+		if (input.parentId) body.parentFolderId = input.parentId;
+		if (input.project) {
+			// Legacy escape hatch: materialized-path, project-scoped folder.
+			return ctx.client.post("project_folders", body, { pathParams: { id: input.project } });
+		}
+		return ctx.client.post("folder_create", body);
 	},
 
 	formatOutput(output: unknown, format: OutputFormat): string {

--- a/src/commands/folders/delete.ts
+++ b/src/commands/folders/delete.ts
@@ -4,24 +4,32 @@ import type { OutputFormat } from "../../lib/output.js";
 
 const inputSchema = z.object({
 	folderId: z.string().uuid().describe("Folder ID to delete"),
+	legacy: z
+		.boolean()
+		.default(false)
+		.describe("Hard-delete a legacy project folder instead of archiving a Knowledge Base folder"),
 });
 
 type Input = z.infer<typeof inputSchema>;
-type Output = { deleted: boolean; folderId: string };
+type Output = { deleted?: boolean; archived?: boolean; folderId: string };
 
 export const foldersDelete: ElnoraCommand<Input, Output> = {
 	name: "folders.delete",
 	group: "folders",
-	description: "Delete a folder",
+	description: "Delete a folder (Knowledge Base folders are archived)",
 	inputSchema,
 	outputSchema: z.any(),
 	annotations: { destructiveHint: true },
 
 	async execute(input, ctx) {
-		await ctx.client.del("folder", {
-			pathParams: { id: input.folderId },
-		});
-		return { deleted: true, folderId: input.folderId };
+		const opts = { pathParams: { id: input.folderId } };
+		if (input.legacy) {
+			await ctx.client.del("folder", opts);
+			return { deleted: true, folderId: input.folderId };
+		}
+		// KB folders are removed by archiving, not hard-deleted.
+		await ctx.client.post("folder_archive", {}, opts);
+		return { archived: true, folderId: input.folderId };
 	},
 
 	formatOutput(output: Output, format: OutputFormat): string {

--- a/src/commands/folders/move.ts
+++ b/src/commands/folders/move.ts
@@ -7,7 +7,8 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 const inputSchema = z.object({
 	folderId: z.string().uuid().describe("Folder ID to move"),
-	parentId: z.string().min(1).describe("Target parent folder ID, or 'root' to move to project root"),
+	parentId: z.string().min(1).describe("Target parent folder ID, or 'root' to move to the top level"),
+	legacy: z.boolean().default(false).describe("Move a legacy project folder instead of a Knowledge Base folder"),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -20,24 +21,24 @@ export const foldersMove: ElnoraCommand<Input> = {
 	outputSchema: z.any(),
 
 	async execute(input, ctx) {
-		let parentValue: string | null;
-		if (input.parentId === "root") {
-			parentValue = null;
-		} else if (UUID_RE.test(input.parentId)) {
-			parentValue = input.parentId;
-		} else {
+		const isRoot = input.parentId === "root";
+		if (!isRoot && !UUID_RE.test(input.parentId)) {
 			throw new ValidationError(
 				"parent must be a valid UUID or 'root'.",
 				"Provide a folder UUID or the literal string 'root'.",
 			);
 		}
-		return ctx.client.put(
-			"folder_move",
-			{ parentId: parentValue },
-			{
-				pathParams: { id: input.folderId },
-			},
-		);
+		const opts = { pathParams: { id: input.folderId } };
+
+		if (input.legacy) {
+			// Deprecated project-folder controller: PUT /folders/{id}/move with MoveFolderDTO.
+			return ctx.client.put("folder_move", { newParentFolderId: isRoot ? null : input.parentId }, opts);
+		}
+		// KB: the dedicated move endpoint can't clear a parent — move-to-root goes through PATCH /folders/{id}.
+		if (isRoot) {
+			return ctx.client.patch("folder", { moveToRoot: true }, opts);
+		}
+		return ctx.client.patch("folder_move", { parentFolderId: input.parentId }, opts);
 	},
 
 	formatOutput(output: unknown, format: OutputFormat): string {

--- a/src/commands/folders/rename.ts
+++ b/src/commands/folders/rename.ts
@@ -5,6 +5,7 @@ import type { OutputFormat } from "../../lib/output.js";
 const inputSchema = z.object({
 	folderId: z.string().uuid().describe("Folder ID"),
 	name: z.string().min(1).describe("New folder name"),
+	legacy: z.boolean().default(false).describe("Rename a legacy project folder instead of a Knowledge Base folder"),
 });
 
 type Input = z.infer<typeof inputSchema>;
@@ -18,13 +19,10 @@ export const foldersRename: ElnoraCommand<Input> = {
 	annotations: { idempotentHint: true },
 
 	async execute(input, ctx) {
-		return ctx.client.put(
-			"folder",
-			{ name: input.name },
-			{
-				pathParams: { id: input.folderId },
-			},
-		);
+		const body = { name: input.name };
+		const opts = { pathParams: { id: input.folderId } };
+		// KB folders use PATCH /folders/{id}; the deprecated project-folder controller uses PUT.
+		return input.legacy ? ctx.client.put("folder", body, opts) : ctx.client.patch("folder", body, opts);
 	},
 
 	formatOutput(output: unknown, format: OutputFormat): string {

--- a/src/commands/orgs/index.ts
+++ b/src/commands/orgs/index.ts
@@ -15,6 +15,7 @@ import { orgsListAll } from "./list-all.js";
 import { orgsMembers } from "./members.js";
 import { orgsRemoveMember } from "./remove-member.js";
 import { orgsResendInvite } from "./resend-invite.js";
+import { orgsSetAutotidy } from "./set-autotidy.js";
 import { orgsSetDefault } from "./set-default.js";
 import { orgsSetStripe } from "./set-stripe.js";
 import { orgsUpdate } from "./update.js";
@@ -42,6 +43,7 @@ export function registerOrgCommands(): ElnoraCommand[] {
 		orgsFiles,
 		orgsListAll,
 		orgsDirectory,
+		orgsSetAutotidy,
 	];
 }
 
@@ -62,6 +64,7 @@ export {
 	orgsMembers,
 	orgsRemoveMember,
 	orgsResendInvite,
+	orgsSetAutotidy,
 	orgsSetDefault,
 	orgsSetStripe,
 	orgsUpdate,

--- a/src/commands/orgs/set-autotidy.ts
+++ b/src/commands/orgs/set-autotidy.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	orgId: z.string().uuid().describe("Organization ID"),
+	enabled: z.boolean().default(false).describe("Enable Knowledge Base auto-tidy (omit to disable)"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const orgsSetAutotidy: ElnoraCommand<Input> = {
+	name: "orgs.setAutotidy",
+	group: "orgs",
+	description: "Enable or disable Knowledge Base auto-tidy for an organization",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { idempotentHint: true },
+
+	async execute(input, ctx) {
+		return ctx.client.patch("org_kb_autotidy", { enabled: input.enabled }, { pathParams: { orgId: input.orgId } });
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/review/approve.ts
+++ b/src/commands/review/approve.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	itemId: z.string().uuid().describe("Review item ID"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const reviewApprove: ElnoraCommand<Input> = {
+	name: "review.approve",
+	group: "review",
+	description: "Approve a Knowledge Base review item, applying its proposed change",
+	inputSchema,
+	outputSchema: z.any(),
+
+	async execute(input, ctx) {
+		return ctx.client.post("kb_review_approve", {}, { pathParams: { id: input.itemId } });
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/review/index.ts
+++ b/src/commands/review/index.ts
@@ -1,0 +1,10 @@
+import type { ElnoraCommand } from "../../core/command.js";
+import { reviewApprove } from "./approve.js";
+import { reviewList } from "./list.js";
+import { reviewReject } from "./reject.js";
+
+export function registerReviewCommands(): ElnoraCommand[] {
+	return [reviewList, reviewApprove, reviewReject];
+}
+
+export { reviewApprove, reviewList, reviewReject };

--- a/src/commands/review/list.ts
+++ b/src/commands/review/list.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	status: z
+		.enum(["pending", "applied", "rejected", "all"])
+		.default("pending")
+		.describe("Filter by review status ('all' lists every state)"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const reviewList: ElnoraCommand<Input> = {
+	name: "review.list",
+	group: "review",
+	description: "List the Knowledge Base review queue (auto-tidy proposals awaiting approval)",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { readOnlyHint: true },
+
+	async execute(input, ctx) {
+		// The backend lists every state when status is empty; "all" maps to that.
+		const status = input.status === "all" ? "" : input.status;
+		return ctx.client.get("kb_review_items", { queryParams: { status } });
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/review/reject.ts
+++ b/src/commands/review/reject.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	itemId: z.string().uuid().describe("Review item ID"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const reviewReject: ElnoraCommand<Input> = {
+	name: "review.reject",
+	group: "review",
+	description: "Reject a Knowledge Base review item without applying its change",
+	inputSchema,
+	outputSchema: z.any(),
+
+	async execute(input, ctx) {
+		return ctx.client.post("kb_review_reject", {}, { pathParams: { id: input.itemId } });
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/tasks/attachment-content.ts
+++ b/src/commands/tasks/attachment-content.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	taskId: z.string().uuid().describe("Task ID"),
+	attachmentId: z.string().uuid().describe("Attachment ID"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const tasksAttachmentContent: ElnoraCommand<Input> = {
+	name: "tasks.attachmentContent",
+	group: "tasks",
+	description: "Get the content of a task attachment",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { readOnlyHint: true },
+
+	async execute(input, ctx) {
+		return ctx.client.get("task_attachment_content", {
+			pathParams: { id: input.taskId, aid: input.attachmentId },
+		});
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { content?: string }).content ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/tasks/attachments.ts
+++ b/src/commands/tasks/attachments.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	taskId: z.string().uuid().describe("Task ID"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const tasksAttachments: ElnoraCommand<Input> = {
+	name: "tasks.attachments",
+	group: "tasks",
+	description: "List the files attached to a task",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { readOnlyHint: true },
+
+	async execute(input, ctx) {
+		return ctx.client.get("task_attachments", { pathParams: { id: input.taskId } });
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { id?: string }).id ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/commands/tasks/index.ts
+++ b/src/commands/tasks/index.ts
@@ -1,14 +1,39 @@
 import type { ElnoraCommand } from "../../core/command.js";
 import { tasksArchive } from "./archive.js";
+import { tasksAttachmentContent } from "./attachment-content.js";
+import { tasksAttachments } from "./attachments.js";
 import { tasksCreate } from "./create.js";
 import { tasksGet } from "./get.js";
 import { tasksList } from "./list.js";
 import { tasksMessages } from "./messages.js";
 import { tasksSend } from "./send.js";
+import { tasksUnarchive } from "./unarchive.js";
 import { tasksUpdate } from "./update.js";
 
 export function registerTaskCommands(): ElnoraCommand[] {
-	return [tasksList, tasksGet, tasksCreate, tasksSend, tasksMessages, tasksUpdate, tasksArchive];
+	return [
+		tasksList,
+		tasksGet,
+		tasksCreate,
+		tasksSend,
+		tasksMessages,
+		tasksUpdate,
+		tasksArchive,
+		tasksUnarchive,
+		tasksAttachments,
+		tasksAttachmentContent,
+	];
 }
 
-export { tasksArchive, tasksCreate, tasksGet, tasksList, tasksMessages, tasksSend, tasksUpdate };
+export {
+	tasksArchive,
+	tasksAttachmentContent,
+	tasksAttachments,
+	tasksCreate,
+	tasksGet,
+	tasksList,
+	tasksMessages,
+	tasksSend,
+	tasksUnarchive,
+	tasksUpdate,
+};

--- a/src/commands/tasks/list.ts
+++ b/src/commands/tasks/list.ts
@@ -5,6 +5,10 @@ import { paginationInput } from "../_shared/pagination.js";
 
 const inputSchema = z.object({
 	project: z.string().uuid().optional().describe("Project ID to filter by"),
+	status: z
+		.enum(["active", "archived", "all"])
+		.optional()
+		.describe("Lifecycle filter: active (default), archived, or all"),
 	...paginationInput,
 });
 
@@ -13,21 +17,18 @@ type Input = z.infer<typeof inputSchema>;
 export const tasksList: ElnoraCommand<Input> = {
 	name: "tasks.list",
 	group: "tasks",
-	description: "List tasks, optionally filtered by project",
+	description: "List tasks, optionally filtered by project or lifecycle status",
 	inputSchema,
 	outputSchema: z.any(),
 	annotations: { readOnlyHint: true },
 
 	async execute(input, ctx) {
+		const queryParams: Record<string, string | number> = { page: input.page, pageSize: input.pageSize };
+		if (input.status) queryParams.status = input.status;
 		if (input.project) {
-			return ctx.client.get("project_tasks", {
-				pathParams: { id: input.project },
-				queryParams: { page: input.page, pageSize: input.pageSize },
-			});
+			return ctx.client.get("project_tasks", { pathParams: { id: input.project }, queryParams });
 		}
-		return ctx.client.get("tasks", {
-			queryParams: { page: input.page, pageSize: input.pageSize },
-		});
+		return ctx.client.get("tasks", { queryParams });
 	},
 
 	formatOutput(output: unknown, format: OutputFormat): string {

--- a/src/commands/tasks/unarchive.ts
+++ b/src/commands/tasks/unarchive.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import type { ElnoraCommand } from "../../core/command.js";
+import type { OutputFormat } from "../../lib/output.js";
+
+const inputSchema = z.object({
+	taskId: z.string().uuid().describe("Task ID to unarchive"),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export const tasksUnarchive: ElnoraCommand<Input> = {
+	name: "tasks.unarchive",
+	group: "tasks",
+	description: "Unarchive a task so it reappears in the default task list",
+	inputSchema,
+	outputSchema: z.any(),
+	annotations: { idempotentHint: true },
+
+	async execute(input, ctx) {
+		await ctx.client.post("task_unarchive", {}, { pathParams: { id: input.taskId } });
+		return { unarchived: true, taskId: input.taskId };
+	},
+
+	formatOutput(output: unknown, format: OutputFormat): string {
+		if (format === "compact") return (output as { taskId?: string }).taskId ?? JSON.stringify(output);
+		return JSON.stringify(output, null, 2);
+	},
+};

--- a/src/core/build-registry.ts
+++ b/src/core/build-registry.ts
@@ -21,6 +21,7 @@ import { registerLibraryCommands } from "../commands/library/index.js";
 import { registerOrgCommands } from "../commands/orgs/index.js";
 import { registerProjectCommands } from "../commands/projects/index.js";
 import { registerProtocolCommands } from "../commands/protocols/index.js";
+import { registerReviewCommands } from "../commands/review/index.js";
 import { registerSearchCommands } from "../commands/search/index.js";
 import { registerTaskCommands } from "../commands/tasks/index.js";
 import { CommandRegistry } from "./registry.js";
@@ -36,6 +37,7 @@ export function buildRegistry(): CommandRegistry {
 		registerFileCommands(),
 		registerOrgCommands(),
 		registerFolderCommands(),
+		registerReviewCommands(),
 		registerSearchCommands(),
 		registerProtocolCommands(),
 		registerLibraryCommands(),

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -57,7 +57,9 @@ export const ENDPOINTS: Record<string, string> = {
 	// Folders (closure-table Knowledge Base — the `folder`/`folder_move` paths are shared with the
 	// legacy controller; the KB read/mutation verbs are distinguished by HTTP method at the call site)
 	folder: "/folders/{id}",
+	folder_create: "/folders",
 	folder_move: "/folders/{id}/move",
+	folder_archive: "/folders/{id}/archive",
 	folders_files: "/folders/files",
 	folder_roots: "/folders/roots",
 	folder_children: "/folders/{id}/children",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -34,6 +34,9 @@ export const ENDPOINTS: Record<string, string> = {
 	tasks: "/tasks",
 	task: "/tasks/{id}",
 	task_messages: "/tasks/{id}/messages",
+	task_unarchive: "/tasks/{id}/unarchive",
+	task_attachments: "/tasks/{id}/attachments",
+	task_attachment_content: "/tasks/{id}/attachments/{aid}/content",
 	// Files
 	files: "/files",
 	file: "/files/{id}",
@@ -80,6 +83,7 @@ export const ENDPOINTS: Record<string, string> = {
 	organizations_all: "/organizations/all",
 	org_files: "/organizations/{orgId}/files",
 	org_member_directory: "/organizations/{orgId}/members/directory",
+	org_kb_autotidy: "/organizations/{orgId}/kb-autotidy",
 	// Organization invitations
 	org_invitations: "/organizations/{orgId}/invitations",
 	org_invitation: "/organizations/{orgId}/invitations/{invId}",
@@ -91,6 +95,10 @@ export const ENDPOINTS: Record<string, string> = {
 	library_files: "/organizations/{orgId}/library/files",
 	library_folders: "/organizations/{orgId}/library/folders",
 	library_folder: "/organizations/{orgId}/library/folders/{id}",
+	// Knowledge Base review queue
+	kb_review_items: "/kb-review-items",
+	kb_review_approve: "/kb-review-items/{id}/approve",
+	kb_review_reject: "/kb-review-items/{id}/reject",
 	// Search
 	search_tasks: "/search/tasks",
 	search_files: "/search/files",


### PR DESCRIPTION
Two batches of the CLI/MCP API-coverage plan, combined into one release.

## Part A — repoint folder mutation to the Knowledge Base

`folders create/rename/move/delete` targeted the **deprecated project-scoped controller**. They now default to the **KB** (the current model, same tree as `folders roots`/`children` + sharing), with legacy behind an escape hatch.

| Command | Default (KB) | Legacy escape |
|---|---|---|
| `folders create --name X` | `POST /folders` | `--project <id>` → project folder |
| `folders rename <id> --name X` | `PATCH /folders/{id}` | `--legacy` → PUT |
| `folders move <id> <parent\|root>` | `PATCH /folders/{id}/move` (root → `{moveToRoot}`) | `--legacy` → PUT |
| `folders delete <id>` | `POST /folders/{id}/archive` | `--legacy` → hard DELETE |

### ⚠️ Behaviour change
- **`folders create` no longer takes a positional `<PROJECT_ID>`** — use `--project <id>` for a legacy project folder.
- rename/move/delete act on **KB folders by default** (`--legacy` for the old ones); `delete` **archives** a KB folder.
- `folders list <PROJECT_ID>` stays legacy — use `folders roots`/`children` for the KB.
- Fixes the folder body field name (`parentFolderId`, was `parentId` — silently ignored).

## Part B — review queue, auto-tidy & task lifecycle

- New `review` group — `review list` / `approve` / `reject` (KB review queue) + the `elnora-review` skill.
- `orgs set-autotidy <org> [--enabled]` — toggle KB auto-tidy.
- `tasks unarchive <id>`, `tasks attachments <id>`, `tasks attachment-content <id> <aid>`; `tasks list --status <active|archived|all>`.

## Testing
- `pnpm typecheck` / `pnpm lint` clean, `pnpm test` — 724 passing
- `pnpm audit:mcp-parity` — **109/109**, 0 mismatches
- Independent code review (approved); verified end-to-end against a local backend (both folder paths, review list, autotidy on/off, task archive→unarchive round-trip)

## Merge order
The MCP-parity check compares against `elnora-mcp-server@main` and stays red until the paired MCP PR merges — please merge that one first, then re-run this check.