### PR TITLE
fix: sync all skills to plugins + refresh skill docs for the new commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,9 +230,13 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           echo "Syncing skills and updating version to $VERSION"
 
-          # Copy skill files
-          for skill in elnora-admin elnora-agent elnora-files elnora-folders elnora-orgs elnora-platform elnora-projects elnora-search elnora-tasks; do
-            cp "skills/$skill/SKILL.md" "elnora-plugins/elnora/skills/$skill/SKILL.md"
+          # Copy every skill (this repo's skills/ is the source of truth), creating
+          # the destination dir so newly-added skills sync automatically instead of
+          # being silently dropped by a hard-coded list.
+          for dir in skills/*/; do
+            skill="$(basename "$dir")"
+            mkdir -p "elnora-plugins/elnora/skills/$skill"
+            cp "$dir/SKILL.md" "elnora-plugins/elnora/skills/$skill/SKILL.md"
           done
 
           # Update plugin.json version

--- a/skills/elnora-files/SKILL.md
+++ b/skills/elnora-files/SKILL.md
@@ -5,7 +5,8 @@ description: >
   "get file content", "view protocol output", "file versions", "version history",
   "download protocol", "upload file", "upload batch", "bulk upload", "create file",
   "archive file", "fork file", "promote file", "working copy", "commit working copy",
-  "update file", "restore version",
+  "update file", "restore version", "share a file", "unshare a file", "file shares",
+  "who can access a file", "move a file to a folder",
   or any task involving Elnora Platform file management.
   NOT for searching file contents across files — use elnora-search for that.
 ---

--- a/skills/elnora-folders/SKILL.md
+++ b/skills/elnora-folders/SKILL.md
@@ -3,7 +3,8 @@ name: elnora-folders
 description: >
   This skill should be used when the user asks to "browse the knowledge base",
   "list KB folders", "show my folders", "open a folder", "create folder",
-  "list folders", "rename folder", "move folder", "delete folder", "organize files
+  "list folders", "rename folder", "move folder", "delete folder", "share a folder",
+  "unshare a folder", "folder permissions", "who can access a folder", "organize files
   into folders", or any task involving Elnora Platform folder management.
 ---
 

--- a/skills/elnora-orgs/SKILL.md
+++ b/skills/elnora-orgs/SKILL.md
@@ -6,7 +6,8 @@ description: >
   "resend invitation", "reinvite", "cancel invitation", "accept invitation",
   "get invitation info", "remove member from org", "organization library",
   "shared library", "library files", "library folders", "set default org",
-  "delete org", "list all orgs", "set stripe",
+  "delete org", "list all orgs", "set stripe", "search members", "member directory",
+  "find a member", "look up a user id to share with", "auto-tidy", "set auto-tidy",
   or any task involving Elnora Platform organization management and shared library resources.
 ---
 

--- a/skills/elnora-platform/SKILL.md
+++ b/skills/elnora-platform/SKILL.md
@@ -81,10 +81,11 @@ Get keys: platform.elnora.ai > Settings > API Keys
 |------|-----------|------------------|
 | List/get/create/update/archive projects, manage members | `elnora-projects` | project, workspace, create project, members, add member |
 | Create/manage/message tasks, protocol generation | `elnora-tasks` | task, protocol, send message, conversation, generate |
-| Browse/read/upload/create/version/fork files | `elnora-files` | file, content, version history, upload, download, fork, working copy |
+| Browse/read/upload/version/fork/share/move files | `elnora-files` | file, content, version history, upload, download, fork, working copy, share file, move file |
 | Find tasks or files by keyword | `elnora-search` | search, find, query |
-| Manage project folder trees | `elnora-folders` | folder, create folder, move folder |
-| Org management, members, billing, invitations, shared library | `elnora-orgs` | organization, org, billing, invite, library |
+| Browse/create/rename/move/delete/share Knowledge Base folders | `elnora-folders` | folder, KB folder, create folder, move folder, share folder |
+| Approve/reject Knowledge Base auto-tidy proposals | `elnora-review` | review queue, KB review, approve, reject, auto-tidy |
+| Org management, members, billing, invitations, member directory, auto-tidy, shared library | `elnora-orgs` | organization, org, billing, invite, member directory, auto-tidy, library |
 | Auth, API keys, account, health, diagnostics | `elnora-admin` | login, logout, profiles, api key, health, account, feedback, audit, completion |
 | Feature flags (SystemAdmin) | `elnora-admin` | feature flag, flags, set flag, list flags |
 | What can the Elnora Agent do? (tools, search, memory) | `elnora-agent` | agent capabilities, agent tools, what can agent do |
@@ -186,15 +187,16 @@ elnora auth         Manage authentication
 elnora completion   Generate shell completion script
 elnora doctor       Run diagnostics (API, auth, version, config checks)
 elnora feedback     Submit feedback
-elnora files        Manage project files (incl. batch upload)
+elnora files        Manage files (share, move, versions, batch upload)
 elnora flags        Manage global feature flags (SystemAdmin)
-elnora folders      Manage project folders
+elnora folders      Manage Knowledge Base folders (browse, share)
 elnora health       Check platform reachability
 elnora library      Manage organization library
 elnora mcp          Run as MCP server (--http or --stdio)
 elnora open         Open platform pages in browser
-elnora orgs         Manage organizations (incl. set-default, delete, list-all)
+elnora orgs         Manage organizations (members, directory, set-autotidy, billing)
 elnora projects     Manage projects
+elnora review       Approve/reject Knowledge Base review-queue items
 elnora search       Search tasks, files, and file content
 elnora setup        Configure AI coding tools (Claude Code, Cursor, VS Code, Codex)
 elnora tasks        Manage tasks

--- a/skills/elnora-tasks/SKILL.md
+++ b/skills/elnora-tasks/SKILL.md
@@ -3,8 +3,9 @@ name: elnora-tasks
 description: >
   This skill should be used when the user asks to "create a task", "send a message",
   "generate a protocol", "list tasks", "get task", "view task details",
-  "read task messages", "update task status", "archive a task", "talk to Elnora",
-  "ask Elnora to generate", "protocol conversation",
+  "read task messages", "update task status", "archive a task", "unarchive a task",
+  "restore a task", "list archived tasks", "task attachments", "read an attachment",
+  "talk to Elnora", "ask Elnora to generate", "protocol conversation",
   or any task involving Elnora Platform task management and protocol generation.
 ---
 


### PR DESCRIPTION
Two related skill-delivery fixes, found while auditing whether the skills fully reflect the current CLI/MCP surface (phases 0–3).

## 1. `sync-skills` dropped new skills (workflow fix)

The release `sync-skills` job looped a **hard-coded 9-skill list** and `cp`'d only into pre-existing dirs, so `elnora-review` (added in v2.5.0) was never synced to the plugin. Now iterates `skills/*/` + `mkdir -p` so any new skill syncs automatically. Only repo-owned filenames used — no workflow-injection surface. (The already-missing skill is seeded directly in the paired `elnora-plugins` PR.)

## 2. Skill docs were complete but under-discoverable (docs fix)

Audited all 10 skills against the live registry (**109 MCP tools — 0 undocumented**, all body sections present). But the *discovery* layer lagged phases 1b–3:

- **Frontmatter triggers** didn't list the new verbs, so a skill might not activate: `elnora-files` (share/unshare/move a file), `elnora-folders` (share/unshare a folder), `elnora-orgs` (member directory, auto-tidy), `elnora-tasks` (unarchive, list archived, attachments).
- **`elnora-platform` router** had no entry for the new `elnora-review` skill and still called folders/files "project" — now Knowledge Base.

Added the missing triggers, the `elnora-review` router row + command, and refreshed the stale wording. No tool/command surface change.

## Verification
- Every one of the 109 tools maps to a documented command; no stale/fabricated tool names; all 10 frontmatters valid; lint clean.
- The exact command syntaxes the skills teach were already E2E-verified against a local backend in the phase 2/3 work.