### PR TITLE
fix(release): strip leading v from version so Homebrew formula is valid

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           cache: "pnpm"
       - name: Sync version from release tag
         run: |
-          VERSION="${GITHUB_REF_NAME##*-v}"
+          VERSION="${GITHUB_REF_NAME#v}"
           echo "Publishing version: $VERSION"
           npm version "$VERSION" --no-git-tag-version --allow-same-version
       - run: pnpm install --frozen-lockfile
@@ -170,7 +170,7 @@ jobs:
 
       - name: Extract version from tag
         run: |
-          VERSION="${GITHUB_REF_NAME##*-v}"
+          VERSION="${GITHUB_REF_NAME#v}"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "Updating Homebrew formula to $VERSION"
 


### PR DESCRIPTION
Fixes the daily 'CI / Validate formula' failures on homebrew-cli and the broken `brew install`.

**Root cause:** the `publish-npm` and `update-homebrew` jobs extract the version with `${GITHUB_REF_NAME##*-v}`, which only strips up to a `-v`. Tags are `vX.Y.Z` (no `-v`), so the `v` survived → the formula got `version "vX.Y.Z"`, and because its URLs are `.../download/v#{version}/...` that became a double-v `vvX.Y.Z` URL (404). `brew audit --strict` correctly failed on the leading `v`.

**Fix:** use `${GITHUB_REF_NAME#v}` (→ `X.Y.Z`), matching the `sync-skills` and `smoke-test` jobs that already do this. Next release regenerates a valid formula. (npm silently coerced the `v` away so publishing wasn't broken, but the same pattern is hardened for consistency.)

Paired with a homebrew-cli PR that fixes the currently-published formula so `brew install` works before the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUhYjxo3aEXF4RZE1oRmtL