### PR TITLE
ci: add PR review dispatch stub

### DIFF
--- a/.github/workflows/pr-review-dispatch.yml
+++ b/.github/workflows/pr-review-dispatch.yml
@@ -1,0 +1,37 @@
+name: PR review dispatch
+
+# On a review request, hand off to the org's centralized review automation for
+# this PR (mirrors release-dispatch.yml). ALL identity/decision logic lives in
+# the private elnora-automation repo — this stub carries none (no usernames, no
+# approval semantics), so it is safe to drop into public repos later.
+#
+# Skips fork PRs: pull_request from a fork gets no secrets, so the dispatch would
+# fail; guarding on head.repo.fork == false makes those runs neutral (skipped),
+# not a red check on external contributors' PRs.
+
+on:
+  pull_request:
+    types: [review_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-review-dispatch-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger centralized review automation
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_DISPATCH_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          jq -n --arg repo "${GITHUB_REPOSITORY#*/}" --arg pr "$PR" \
+            '{ref:"main",inputs:{repo:$repo,pr:$pr}}' \
+          | gh api --method POST \
+              /repos/Elnora-AI/elnora-automation/actions/workflows/review-approve.yml/dispatches \
+              --input -


### PR DESCRIPTION
Thin stub that forwards review-request events to the org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)